### PR TITLE
graphql support querying course/section based on coursehash/sectionhash

### DIFF
--- a/Keys.js
+++ b/Keys.js
@@ -111,6 +111,21 @@ class Keys {
 
     return hash;
   }
+
+  static parseSectionHash(hash) {
+    const hashSplit = hash.split('/');
+    if (!(hashSplit && hashSplit.length === 5)) {
+      macros.error('Invalid class hash', hash);
+      return null;
+    }
+    return {
+      host: hashSplit[0],
+      termId: hashSplit[1],
+      subject: hashSplit[2],
+      classId: hashSplit[3],
+      crn: hashSplit[4],
+    }
+  }
 }
 
 

--- a/graphql/tests/__snapshots__/class.test.seq.ts.snap
+++ b/graphql/tests/__snapshots__/class.test.seq.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`gets all occurrences 1`] = `
+exports[`class query gets all occurrences 1`] = `
 Object {
   "data": Object {
     "class": Object {
@@ -25,7 +25,7 @@ Object {
 }
 `;
 
-exports[`gets latest occurrence 1`] = `
+exports[`class query gets latest occurrence 1`] = `
 Object {
   "data": Object {
     "class": Object {
@@ -45,7 +45,7 @@ Object {
 }
 `;
 
-exports[`gets specific occurrence 1`] = `
+exports[`class query gets specific occurrence 1`] = `
 Object {
   "data": Object {
     "class": Object {
@@ -65,11 +65,57 @@ Object {
 }
 `;
 
-exports[`gets the name of class from subject and classId 1`] = `
+exports[`class query gets the name of class from subject and classId 1`] = `
 Object {
   "data": Object {
     "class": Object {
       "name": "Fundamentals of Computer Science 1",
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
+exports[`classByHash query gets class from class hash 1`] = `
+Object {
+  "data": Object {
+    "classByHash": Object {
+      "classId": 2500,
+      "name": "Fundamentals of Computer Science 1",
+      "subject": "CS",
+      "termId": 201830,
+    },
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
+exports[`sectionByHash query gets section from section id 1`] = `
+Object {
+  "data": Object {
+    "sectionByHash": Object {
+      "campus": "Boston",
+      "classId": "2500",
+      "classType": "Lecture",
+      "crn": "12345",
+      "honors": false,
+      "meetings": Object {},
+      "seatsCapacity": 5,
+      "seatsRemaining": 2,
+      "subject": "CS",
+      "termId": "201830",
     },
   },
   "errors": undefined,

--- a/graphql/tests/class.test.seq.ts
+++ b/graphql/tests/class.test.seq.ts
@@ -35,65 +35,122 @@ beforeAll(async () => {
       lastUpdateTime: new Date(),
     },
   });
-});
 
-it('gets all occurrences', async () => {
-  const res = await query({
-    query: gql`
-      query class {
-        class(subject: "CS", classId: "2500") {
-          name
-          allOccurrences {
-            termId
+  await prisma.section.create({
+    data: {
+      id: 'neu.edu/201830/CS/2500/12345',
+      seatsCapacity: 5,
+      seatsRemaining: 2,
+      campus : 'Boston',
+      honors: false,
+      crn: '12345',
+      meetings: {},
+      classType: 'Lecture',
+    },
+  });
+});
+describe('class query', () => {
+  it('gets all occurrences', async () => {
+    const res = await query({
+      query: gql`
+        query class {
+          class(subject: "CS", classId: "2500") {
+            name
+            allOccurrences {
+              termId
+            }
           }
         }
-      }
-    `,
+      `,
+    });
+    expect(res).toMatchSnapshot();
   });
-  expect(res).toMatchSnapshot();
-});
-
-it('gets latest occurrence', async () => {
-  const res = await query({
-    query: gql`
-      query class {
-        class(subject: "CS", classId: "2500") {
-          name
-          latestOccurrence {
-            termId
+  
+  it('gets latest occurrence', async () => {
+    const res = await query({
+      query: gql`
+        query class {
+          class(subject: "CS", classId: "2500") {
+            name
+            latestOccurrence {
+              termId
+            }
           }
         }
-      }
-    `,
+      `,
+    });
+    expect(res).toMatchSnapshot();
   });
-  expect(res).toMatchSnapshot();
-});
-
-it('gets specific occurrence', async () => {
-  const res = await query({
-    query: gql`
-      query class {
-        class(subject: "CS", classId: "2500") {
-          name
-          occurrence(termId: "201930") {
-            termId
+  
+  it('gets specific occurrence', async () => {
+    const res = await query({
+      query: gql`
+        query class {
+          class(subject: "CS", classId: "2500") {
+            name
+            occurrence(termId: "201930") {
+              termId
+            }
           }
         }
-      }
-    `,
+      `,
+    });
+    expect(res).toMatchSnapshot();
   });
-  expect(res).toMatchSnapshot();
+  
+  it('gets the name of class from subject and classId', async () => {
+    const res = await query({
+      query: gql`
+        query class {
+          class(subject: "CS", classId: "2500") {
+            name
+          }
+        }
+      `,
+    });
+    expect(res).toMatchSnapshot();
+  });
 });
 
-it('gets the name of class from subject and classId', async () => {
-  const res = await query({
-    query: gql`
-      query class {
-        class(subject: "CS", classId: "2500") {
+describe('classByHash query', () => {
+  it('gets class from class hash', async () => {
+    const res = await query({
+      query: gql`
+      query classByHash {
+        classByHash(hash: "neu.edu/201830/CS/2500") {
           name
+          subject
+          classId
+          termId
         }
       }
-    `,
+      `,
+    });
+    expect(res).toMatchSnapshot();
   });
-  expect(res).toMatchSnapshot();
 });
+
+describe('sectionByHash query', () => {
+  it('gets section from section id', async () => {
+    const res = await query({
+      query: gql`
+      query sectionByHash {
+        sectionByHash(hash: "neu.edu/201830/CS/2500/12345") {
+          termId
+          subject
+          classId
+          classType
+          crn
+          seatsCapacity
+          seatsRemaining
+          campus
+          honors
+          meetings
+        }
+      }
+      `,
+    });
+    expect(res).toMatchSnapshot();
+  });
+});
+

--- a/graphql/typeDefs/class.js
+++ b/graphql/typeDefs/class.js
@@ -2,7 +2,9 @@ import { gql } from 'apollo-server';
 
 const typeDef = gql`
   extend type Query {
-    class(subject: String!, classId: String!): Class
+    class(subject: String!, classId: String!): Class,
+    classByHash(hash: String!): ClassOccurrence,
+    sectionByHash(hash: String!): Section
   }
 
   type Class {


### PR DESCRIPTION
## why
SearchNEU wants to query for course/sections based on the course hash and section hash.

## what
Added support for graphql to handle these types of queries.