### PR TITLE
Add fields to GraphQL typedefs to convert search over to GraphQL

### DIFF
--- a/graphql/typeDefs/classOccurrence.js
+++ b/graphql/typeDefs/classOccurrence.js
@@ -38,6 +38,7 @@ const typeDef = gql`
     profs: [String!]!
     meetings: JSON
     host: String!
+    lastUpdateTime: Float
   }
 `;
 

--- a/graphql/typeDefs/classOccurrence.js
+++ b/graphql/typeDefs/classOccurrence.js
@@ -17,8 +17,9 @@ const typeDef = gql`
     classAttributes: [String!]!
     url: String!
     lastUpdateTime: Float
-
+    nupath: [String!]!
     sections: [Section!]!
+    host: String!
   }
 
   type Section {
@@ -36,6 +37,7 @@ const typeDef = gql`
     url: String!
     profs: [String!]!
     meetings: JSON
+    host: String!
   }
 `;
 


### PR DESCRIPTION
SearchNEU needs the GraphQL classOccurrence and Section typedefs to have some additional properties.

See https://github.com/sandboxnu/searchneu/pull/83