### PR TITLE
Add Sections For ClassOccurrence Resolvers

### DIFF
--- a/graphql/resolvers/class.ts
+++ b/graphql/resolvers/class.ts
@@ -2,35 +2,45 @@
  * This file is part of Search NEU and licensed under AGPL3.
  * See the license file in the root folder for details.
  */
-import prisma from '../../services/prisma';
-import HydrateCourseSerializer from '../../serializers/hydrateCourseSerializer';
-import keys from '../../utils/keys';
+import prisma from "../../services/prisma";
+import HydrateCourseSerializer from "../../serializers/hydrateCourseSerializer";
+import keys from "../../utils/keys";
 
 const serializer = new HydrateCourseSerializer();
 
 const serializeValues = (results) => {
   return results.map((result) => serializer.serializeCourse(result));
-}
+};
 
 const getLatestClassOccurrence = async (subject, classId) => {
-  const results = await prisma.course.findMany({ where: { subject, classId }, orderBy: { termId: 'desc' } });
+  const results = await prisma.course.findMany({
+    where: { subject, classId },
+    include: { sections: true },
+    orderBy: { termId: "desc" },
+  });
   return serializeValues(results)[0];
-}
+};
 
 const getAllClassOccurrences = async (subject, classId) => {
-  const results = await prisma.course.findMany({ where: { subject, classId }, orderBy: { termId: 'desc' } });
+  const results = await prisma.course.findMany({
+    where: { subject, classId },
+    include: { sections: true },
+    orderBy: { termId: "desc" },
+  });
+  console.log(results.map(result => result.sections));
   return serializeValues(results);
-}
+};
 
 const getClassOccurrence = async (termId, subject, classId) => {
   const res = await prisma.course.findUnique({
     where: {
       uniqueCourseProps: { subject, classId, termId },
     },
+    include: { sections: true },
   });
 
   return serializeValues([res])[0];
-}
+};
 
 const getClassOccurrenceById = async (id) => {
   const res = await prisma.course.findUnique({
@@ -38,7 +48,7 @@ const getClassOccurrenceById = async (id) => {
   });
 
   return serializeValues([res])[0];
-}
+};
 
 const getSectionById = async (id) => {
   const res = await prisma.section.findUnique({
@@ -46,18 +56,33 @@ const getSectionById = async (id) => {
   });
   const { termId, subject, classId } = keys.parseSectionHash(id);
   return { termId, subject, classId, ...res };
-}
+};
 
 const resolvers = {
   Query: {
-    class: (parent, args) => { return getLatestClassOccurrence(args.subject, args.classId && args.classId); },
-    classByHash: (parent, args) => { return getClassOccurrenceById(args.hash); },
-    sectionByHash: (parent, args) => { return getSectionById(args.hash); }
+    class: (parent, args) => {
+      return getLatestClassOccurrence(
+        args.subject,
+        args.classId && args.classId
+      );
+    },
+    classByHash: (parent, args) => {
+      return getClassOccurrenceById(args.hash);
+    },
+    sectionByHash: (parent, args) => {
+      return getSectionById(args.hash);
+    },
   },
   Class: {
-    latestOccurrence: (clas) => { return getLatestClassOccurrence(clas.subject, clas.classId); },
-    allOccurrences: (clas) => { return getAllClassOccurrences(clas.subject, clas.classId); },
-    occurrence: (clas, args) => { return getClassOccurrence(args.termId, clas.subject, clas.classId); },
+    latestOccurrence: (clas) => {
+      return getLatestClassOccurrence(clas.subject, clas.classId);
+    },
+    allOccurrences: (clas) => {
+      return getAllClassOccurrences(clas.subject, clas.classId);
+    },
+    occurrence: (clas, args) => {
+      return getClassOccurrence(args.termId, clas.subject, clas.classId);
+    },
   },
 };
 


### PR DESCRIPTION
# what 
For class pages, we want to make the `class(subject: String!, classId: String!)` graphQL query instead of the standard `search` query. The resolvers on the ClassOccurrences were not returning Section info, causing the desired query to get an error response.

# how 
Add `include: { sections: true }` in prisma in all the resolvers that return a ClassOccurrence.

# additional issues/questions
The GraphQL typedef for Sections includes a `termId` field but the Sections in ClassOccurrences returned from resolvers do not have this field.