### PR TITLE
Fix Scrapers For Min/Max Credits

### DIFF
--- a/scrapers/classes/parsersxe/classParser.js
+++ b/scrapers/classes/parsersxe/classParser.js
@@ -104,8 +104,8 @@ class ClassParser {
         "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_listcrse?" +
         `term_in=${termId}&subj_in=${subjectCode}&crse_in=${courseNumber}&schd_in=%`,
       lastUpdateTime: Date.now(),
-      maxCredits: SR.creditHourLow,
-      minCredits: SR.creditHourHigh || SR.creditHourLow,
+      maxCredits: SR.creditHourHigh || SR.creditHourLow,
+      minCredits: SR.creditHourLow,
       college: collegeNames[termId.charAt(termId.length - 1)],
       feeAmount,
       feeDescription,


### PR DESCRIPTION
# what 
Scrapers were reversing minCredits and maxCredits

# fix
If minCredits and maxCredits are the same, scrapers will get 0 for `creditHourHigh` and the number of credits for `creditHourLow`. Therefore `maxCredits` should be `creditHourHigh` if it exists and `creditHourLow` otherwise.