### PR TITLE
Fix How Updater Sends NotificationInfo to Notifyer

### DIFF
--- a/services/updater.ts
+++ b/services/updater.ts
@@ -264,6 +264,11 @@ class Updater {
     req.on("error", (e) => {
       macros.error(`problem with updater request: ${e.message}`);
     });
+    req.on("response", (res) => {
+      if (res.statusCode !== 200) {
+        macros.error(res.statusCode, res.statusMessage);
+      }
+    });
     httpSignature.sign(req, {
       key: key,
       keyId: "hello",


### PR DESCRIPTION
# what 
The notification info wasn't being sent in the request to Search's notifyer.

# how 
Just do `req.end(body)` instead of `req.write(body)`. Also for local dev work, the request should be http not https.

# IMPORTANT!! notes on merging this into prod 
- If there isn't one already, we need a `WEBHOOK_PRIVATE_KEY` environment variable and `UPDATER_URL` on prod

## how to generate public and private key
Run this command in your terminal `ssh-keygen -m PEM -t rsa -b 4096 -C "youremail@example.com"`, type in the name of the file you want the keys to be in, and your private key will be named `yourFileName.pub` and your public key will be named `yourFileName`