### PR TITLE
Copy scripts folder in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN yarn install --frozen-lockfile
 COPY graphql /app/graphql
 COPY prisma /app/prisma
 COPY scrapers /app/scrapers
+COPY scripts /app/scripts
 COPY serializers /app/serializers
 COPY services /app/services
 COPY types /app/types


### PR DESCRIPTION
# what
The updater was exiting early on AWS, we want to fix that.

# how
The Dockerfile wasn't copying the `scripts` folder, so we add a line to copy it.