### PR TITLE
Make Course ClassId String instead of Int

### DIFF
--- a/graphql/typeDefs/classOccurrence.js
+++ b/graphql/typeDefs/classOccurrence.js
@@ -4,7 +4,7 @@ const typeDef = gql`
   type ClassOccurrence {
     name: String!
     subject: String!
-    classId: Int!
+    classId: String!
     termId: Int!
 
     desc: String!


### PR DESCRIPTION
# what 
Previously, the type definition for a Course in GraphQL had integer `classId`s. This is a problem because there are classes like `ESLG 0045` whose classId should be `0045`, not `45`. Right now, CCA is sending the wrong classId for classes like `ESLG 0045` so this PR addresses the bug.