### PR TITLE
Make termID defined as String consistently 

### DIFF
--- a/graphql/typeDefs/classOccurrence.js
+++ b/graphql/typeDefs/classOccurrence.js
@@ -5,7 +5,7 @@ const typeDef = gql`
     name: String!
     subject: String!
     classId: String!
-    termId: Int!
+    termId: String!
 
     desc: String!
     prereqs: JSON

--- a/graphql/typeDefs/search.js
+++ b/graphql/typeDefs/search.js
@@ -3,7 +3,7 @@ import { gql } from "apollo-server";
 const typeDef = gql`
   extend type Query {
     search(
-      termId: Int!
+      termId: String!
       query: String
       subject: [String!]
       nupath: [String!]


### PR DESCRIPTION
termId was defined as an int in some places and as a string in other places. Made back end changes that keep termId as a string consistently. 