### PR TITLE
properly await update, catch error, exit on error

### DIFF
--- a/services/updater.ts
+++ b/services/updater.ts
@@ -61,15 +61,20 @@ class Updater {
     // In dev the cache will be used so we are not actually hitting NEU's servers anyway.
     const intervalTime = macros.PROD ? 300000 : 30000;
 
-    const interval = setInterval(async () => {
-      try {
-        await this.update();
-      } catch (e) {
-        macros.warn("Updater failed with: ", e);
-        clearInterval(interval);
-        process.exit(1); // if updater fails, exit the process so we can spin up a new task and not hang
-      }
+    setInterval(() => {
+      this.updateOrExit();
     }, intervalTime);
+
+    this.updateOrExit();
+  }
+
+  async updateOrExit(): Promise<void> {
+    try {
+      await this.update();
+    } catch (e) {
+      macros.warn("Updater failed with: ", e);
+      process.exit(1); // if updater fails, exit the process so we can spin up a new task and not hang
+    }
   }
 
   // Update classes and sections users and notify users if seats have opened up

--- a/services/updater.ts
+++ b/services/updater.ts
@@ -61,15 +61,15 @@ class Updater {
     // In dev the cache will be used so we are not actually hitting NEU's servers anyway.
     const intervalTime = macros.PROD ? 300000 : 30000;
 
-    setInterval(() => {
+    const interval = setInterval(async () => {
       try {
-        this.update();
+        await this.update();
       } catch (e) {
         macros.warn("Updater failed with: ", e);
+        clearInterval(interval);
         process.exit(1); // if updater fails, exit the process so we can spin up a new task and not hang
       }
     }, intervalTime);
-    this.update();
   }
 
   // Update classes and sections users and notify users if seats have opened up
@@ -95,10 +95,12 @@ class Updater {
 
     const dumpProcessorStartTime = Date.now();
     macros.log("running dump processor");
+
     await dumpProcessor.main({
       termDump: { sections, classes: {}, subjects: {} },
       destroy: true,
     });
+
     macros.log(
       `finished running dump processor in ${
         Date.now() - dumpProcessorStartTime


### PR DESCRIPTION
# what 
Updater hangs in prod and errors weren't being caught.

# how 
Properly await the `update()` method, catch error, and exit the process on error. This will force AWS to spin up a new ECS task for the updater.