### PR TITLE
Add endpoint for posting feedback

### DIFF
--- a/infrastructure/dev/docker-compose-server.yml
+++ b/infrastructure/dev/docker-compose-server.yml
@@ -36,5 +36,6 @@ services:
       TWILIO_VERIFY_SERVICE_ID:
       CLIENT_ORIGIN: http://localhost:5000
       JWT_SECRET:
+      SLACK_WEBHOOK_URL:
 volumes:
   pg:

--- a/twilio/server.ts
+++ b/twilio/server.ts
@@ -153,7 +153,7 @@ app.post("/feedback", async (req, res) => {
   const parsed_data = JSON.stringify(data);
 
   return await request
-    .post({ url: process.env.SLACK_WEBHOOK_SECRET, body: parsed_data })
+    .post({ url: process.env.SLACK_WEBHOOK_URL, body: parsed_data })
     .then((_) => res.status(200).send())
     .catch((error) => {
       macros.error(error);


### PR DESCRIPTION
# Purpose

The feedback/contact buttons do not work. This adds a feedback endpoint to the notifs server, which notifies the Search team on Slack.

<br>

# Tickets

https://trello.com/c/MzKg5kJT/288-feedback-buttons-are-inactionable


# Contributors

- @hankewyczz 

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
