### PR TITLE
add initializing indices if not existing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,43 +2,7 @@
 
 ## Installation
 
-1. If you don't have these on your machine, install:
-
-- git
-- node
-- yarn
-- Docker Desktop
-
-2. Launch Docker Desktop by clicking on the app
-3. Clone the repo by running `git clone https://github.com/sandboxnu/course-catalog-api.git` in your terminal
-4. In your terminal, navigate to this project and run the following commands:
-
-- `yarn install`
-- `yarn dev:docker`
-- `yarn db:migrate`
-- `yarn db:refresh`
-- Optional step: if you have a cache zip/folder, unzip it, make sure it's named `cache` and place it in the root level of the project so your project directory looks something like this:
-
-```
-PROJECT
-  |
-  -- package.json
-  -- ...
-  -- cache
-      |
-      -- dev_data
-          |
-          -- v2
-      -- requests
-```
-
-This step allows you to quickly insert the course catalog data into your database by using a cache with all the information instead of having to run the full scrapers.
-
-- `yarn scrape`
-- `yarn dev`
-
-5. At this point, you should be able to use the GraphQL API by visiting `localhost:4000`
-
+Read `documentation/onboarding_setup`
 ## Custom Scraping
 
 Scraping course data for multiple terms can take quite a bit of time. Caching scrapes is fantastic for quickly initializing local databases, but for scraper-related work we might need to run real scrapes often. In order to speed up scraper-related dev work we can specify custom scraping filters so that we only fetch data for a subset of the total courses for the given terms. Filters are specified in `scrapers/filters.ts` in the following format:

--- a/documentation/onboarding_setup.md
+++ b/documentation/onboarding_setup.md
@@ -22,7 +22,7 @@ Throughout this, we link to other sites for installation instructions. Those sit
 
 To work on this project, you\'ll need a UNIX-based terminal. Mac/Linux users already have this - Windows users should install WSL, the Windows Subsystem for Linux.
 
-[WSL installation instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (If this link doesn\'t work, just use the most current instructions provided by Microsoft).
+[WSL installation instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (If this link doesn\'t work, just use the most current instructions provided by Microsoft). Also make sure to [upgrade to version 2](https://docs.microsoft.com/en-us/windows/wsl/install#upgrade-version-from-wsl-1-to-wsl-2).
 
 We also recommend installing [Windows Terminal](https://docs.microsoft.com/en-us/windows/terminal/install) - this provides a much more pleasant experience than the Command Prompt.
 

--- a/documentation/onboarding_setup.md
+++ b/documentation/onboarding_setup.md
@@ -61,6 +61,19 @@ To get around that, we use a course cache. You can get it from any of our curren
 - Unzip the `cache.zip` file, and move the contents to a directory named `cache` in the **root** of the repository
   - ie. `course-catalog-api/cache` (Make sure there isn\'t a `cache` directory in the `cache` directory - depending on how you unzip it, it might have created a nested directory.)
 
+```
+PROJECT
+  |
+  -- package.json
+  -- ...
+  -- cache
+      |
+      -- dev_data
+          |
+          -- v2
+      -- requests
+```
+
 #### Run
 
 The fun part - run these commands, one after the other.

--- a/documentation/onboarding_setup.md
+++ b/documentation/onboarding_setup.md
@@ -1,0 +1,94 @@
+# Onboarding & SearchNEU Setup
+
+## Overview
+
+**"SearchNEU"**, as a complete application, exists in two parts:
+
+- Backend: The backend is our API server, which does all of the heavy lifting. This stores all of the course data - names, IDs, sections, descriptions, etc. It also handles notifications. The user can interact with this data using the frontend.
+  - The backend is also used by other applications (like GraduateNU).
+- Frontend: The frontend is what a user sees when they go to [searchneu.com](https://searchneu.com). It does not have any data on its own - whenever a user searches for a course, the frontend sends a request to the backend, which returns the data. The frontend handles display; the backend handles data processing.
+
+## Backend Setup
+
+### Prerequisites
+
+This setup guide tries its best not to assume people have background knowledge, and provides basic setup instructions.
+
+#### Notes
+
+Throughout this, we link to other sites for installation instructions. Those sites will have more updated infomation, and will serve as the source of truth for the installs.
+
+#### Terminal
+
+To work on this project, you\'ll need a UNIX-based terminal. Mac/Linux users already have this - Windows users should install WSL, the Windows Subsystem for Linux.
+
+[WSL installation instructions](https://docs.microsoft.com/en-us/windows/wsl/install-win10) (If this link doesn\'t work, just use the most current instructions provided by Microsoft).
+
+We also recommend installing [Windows Terminal](https://docs.microsoft.com/en-us/windows/terminal/install) - this provides a much more pleasant experience than the Command Prompt.
+
+#### Docker Desktop
+
+- Install [Docker Desktop](https://docs.docker.com/desktop)
+- Ensure that `docker-compose` was installed
+  - Run `docker-compose --help` in your terminal to check
+  - If using Windows, ensure that WSL2 integration is enabled ([WSL integration](https://docs.docker.com/desktop/windows/wsl/))
+
+#### Node Version Manager (nvm)
+
+- Install [NVM](https://github.com/nvm-sh/nvm)
+  - This helps you manage Node versions - we have some legacy dependencies (hopefully not for much longer) which limit us
+- Install Node
+  - Check the status of this PR: https://github.com/sandboxnu/course-catalog-api/pull/64
+  - If this PR has been merged:
+    - Skip to "Clone the backend repo", and run `nvm use`.
+    - There is a file called `.nvmrc` in the repository, which tells `nvm` which version to use
+  - If the PR has not been merged:
+    - Use Node `12.18`
+
+#### Yarn
+
+- Run `npm i -g yarn`
+- This will install `yarn` globally, which helps us manage our dependencies.
+
+### Install/Setup
+
+#### Unpack the cache
+
+Scraping the course information from Northeastern takes a long time, and it resource (memory/network) intensive. Also, we don\'t want to break Banner\'s servers 🙃.
+
+To get around that, we use a course cache. You can get it from any of our current members - it will be a `.zip` file containing the course data.
+
+- Unzip the `cache.zip` file, and move the contents to a directory named `cache` in the **root** of the repository
+  - ie. `course-catalog-api/cache` (Make sure there isn\'t a `cache` directory in the `cache` directory - depending on how you unzip it, it might have created a nested directory.)
+
+#### Run
+
+The fun part - run these commands, one after the other.
+
+- `yarn install` - installs all of our dependencies (only installs them locally, specific to this project)
+- `yarn dev:docker` - creates a Docker container for our database (Postgres) and for Elasticsearch (which helps us return results for search queries)
+- `yarn db:migrate` - sets up our database with all of the tables/structures that we need
+- `yarn db:refresh` - generates a custom Prisma client for our project
+  - Prisma is an [ORM](https://en.wikipedia.org/wiki/Object-relational_mapping) - it allows us to interface with our database using Javascript, instead of SQL.
+- `yarn scrape` - this command _would_ scrape Northeastern for course data, but since we have a `cache` directory, it just populates our database with the cached data.
+- `yarn scrape` - yes, run it again. This second pass-through is necessary to generate the table for the term IDs, based off of the historical course data we have.
+- `yarn dev` - This should, at this point, let you use the GraphQL API (try hitting http://localhost:4000/ to see the GraphQL playground)
+
+## Frontend Setup
+
+This is a lot easier.
+
+- Download the repo:
+  - `git clone https://github.com/sandboxnu/searchneu`
+- Run the following:
+  - `yarn install`
+  - `yarn migrate`
+  - `yarn dev:fullstack` (WITH THE BACKEND RUNNING)
+
+You should now have a fully functional Search instance (at http://localhost:5000)
+
+## Common Errors
+
+- at the end: we were running into a problem where cache was taking much longer than expected, and will continue to update on how this turns out.
+  - The scrapers don\'t seem to be reading from the cache not sure why that\'s happening
+- recorded eddy\'s frontend setup to becca\'s zoom cloud

--- a/utils/elastic.ts
+++ b/utils/elastic.ts
@@ -5,7 +5,7 @@
  */
 
 import { Client } from "@elastic/elasticsearch";
-import _ from "lodash";
+import _, { map } from "lodash";
 import pMap from "p-map";
 import macros from "./macros";
 import {
@@ -27,46 +27,55 @@ const BULKSIZE = 5000;
 type ElasticIndex = {
   name: string;
   mapping: any;
-  alias: string;
 };
 
 export class Elastic {
   public CLASS_ALIAS: string;
   public EMPLOYEE_ALIAS: string;
 
-  private classIndex: ElasticIndex;
-  private employeeIndex: ElasticIndex;
-  private indexes: ElasticIndex[];
-  private initializing: Promise<void>;
+  private indexes: Record<string, ElasticIndex>;
 
   constructor() {
     // Because we export an instance of this class, put the constants on the instance.
     this.CLASS_ALIAS = "classes";
     this.EMPLOYEE_ALIAS = "employees";
 
-    this.classIndex = {
+    const classIndex = {
       name: "",
       mapping: classMap,
-      alias: this.CLASS_ALIAS,
     };
-    this.employeeIndex = {
+    const employeeIndex = {
       name: "",
       mapping: employeeMap,
-      alias: this.EMPLOYEE_ALIAS,
     };
-    this.indexes = [this.classIndex, this.employeeIndex];
+    this.indexes = {};
+    this.indexes[this.CLASS_ALIAS] = classIndex;
+    this.indexes[this.EMPLOYEE_ALIAS] = employeeIndex;
+  }
+
+  async fetchIndexNames(): Promise<void> {
+    const aliases = Object.keys(this.indexes);
+    await Promise.all(
+      aliases.map(async (alias) => await this.fetchIndexName(alias))
+    );
   }
 
   // This method fetches the exact index name since they are now dynamically named green or blue
-  async fetchIndexNames() {
-    const isClassesBlue = await this.doesIndexExist("classes_blue");
-    const employeesBlue = await this.doesIndexExist("employees_blue");
+  async fetchIndexName(aliasName: string): Promise<void> {
+    const { mapping } = this.indexes[aliasName];
+    const isBlue = await this.doesIndexExist(`${aliasName}_blue`);
+    const isGreen = await this.doesIndexExist(`${aliasName}_green`);
 
-    const classesName = isClassesBlue ? "classes_blue" : "classes_green";
-    const employeesName = employeesBlue ? "employees_blue" : "employees_green";
-
-    this.classIndex.name = classesName;
-    this.employeeIndex.name = employeesName;
+    // if neither index exists, create a new index
+    if (!isBlue && !isGreen) {
+      const indexName = `${aliasName}_blue`;
+      await this.createIndex(indexName, mapping);
+      await this.createAlias(indexName, aliasName);
+    } else if (isBlue) {
+      this.indexes[aliasName].name = `${aliasName}_blue`;
+    } else {
+      this.indexes[aliasName].name = `${aliasName}_green`;
+    }
   }
 
   async isConnected(): Promise<boolean> {
@@ -78,35 +87,64 @@ export class Elastic {
     return true;
   }
 
+  async createIndex(indexName: string, mapping): Promise<void> {
+    macros.log(`Creating index ${indexName}`);
+    await client.indices
+      .create({
+        index: indexName,
+        body: mapping,
+      })
+      .then(() => {
+        macros.log(`Created index ${indexName}`);
+      })
+      .catch((e) => macros.log(`Error creating index ${indexName}: ${e}`));
+  }
+
+  async deleteIndex(indexName: string): Promise<void> {
+    macros.log(`Deleting index ${indexName}`);
+    await client.indices
+      .delete({
+        index: indexName,
+      })
+      .then(() => {
+        macros.log(`Deleted index ${indexName}`);
+      })
+      .catch((e) => macros.log(`Error deleting index ${indexName}: ${e}`));
+  }
+
+  async createAlias(indexName: string, aliasName: string): Promise<void> {
+    macros.log(`Aliasing index ${indexName} as ${aliasName}`);
+    await client.indices
+      .putAlias({
+        index: indexName,
+        name: aliasName,
+      })
+      .then(() => {
+        macros.log(`Aliased index ${indexName} as ${aliasName}`);
+      })
+      .catch((e) =>
+        macros.log(`Error aliasing ${indexName} as ${aliasName}: ${e}`)
+      );
+  }
+
   // replace an index with a fresh one with a specified mapping
   async resetIndex(): Promise<void> {
     await this.fetchIndexNames();
 
-    for (const index of this.indexes) {
-      const { name, mapping, alias } = index;
+    const aliases = Object.keys(this.indexes);
+    for (const alias of aliases) {
+      const { name, mapping } = this.indexes[alias];
 
       const exists = await this.doesIndexExist(name);
       if (exists) {
         // Clear out the index.
-        macros.log(`Deleting index ${name}`);
-        await client.indices.delete({ index: name });
-        macros.log(`Deleted mapping for index ${name}`);
+        await this.deleteIndex(name);
       }
-      // Put in the new classes mapping (elasticsearch doesn't let you change mapping of existing index)
-      macros.log(`Creating index ${name}`);
-      await client.indices.create({
-        index: name,
-        body: mapping,
-      });
-      macros.log(`Created index ${name}`);
+      // Put in the new mapping (elasticsearch doesn't let you change mapping of existing index)
+      await this.createIndex(name, mapping);
 
       // Once we create a new index, we need to alias it
-      macros.log(`Aliasing index ${name} as ${alias}`);
-      await client.indices.putAlias({
-        index: name,
-        name: alias,
-      });
-      macros.log(`Aliased index ${name} as ${alias}`);
+      await this.createAlias(name, alias);
     }
   }
 
@@ -114,8 +152,10 @@ export class Elastic {
   async resetIndexWithoutLoss(): Promise<void> {
     await this.fetchIndexNames();
 
-    for (const index of this.indexes) {
-      const { name, mapping, alias } = index;
+    const aliases = Object.keys(this.indexes);
+    for (const alias of aliases) {
+      const { name, mapping } = this.indexes[alias];
+
       const exists = await this.doesIndexExist(name);
 
       // If the index doesn't exist, we can't reindex without loss of data
@@ -135,12 +175,7 @@ export class Elastic {
         nextIndexName = indexName + "_blue";
       }
 
-      macros.log(`Creating index ${nextIndexName}`);
-      await client.indices.create({
-        index: nextIndexName,
-        body: mapping,
-      });
-      macros.log(`Created index ${nextIndexName}`);
+      this.createIndex(nextIndexName, mapping);
 
       // Reindex data from the old (current) into the newly made index
       // If the mappings between the two indexes are drastically different,
@@ -175,20 +210,13 @@ export class Elastic {
       macros.log(`Reindexed data from index ${name} to ${nextIndexName}`);
 
       // Change the alias to point to our new index
-      macros.log(`Aliasing index ${nextIndexName} as ${alias}`);
-      await client.indices.putAlias({
-        index: nextIndexName,
-        name: alias,
-      });
-      macros.log(`Aliased index ${nextIndexName} as ${alias}`);
+      await this.createAlias(nextIndexName, alias);
 
       // Delete the old index
-      macros.log(`Deleting index ${name}`);
-      await client.indices.delete({ index: name });
-      macros.log(`Deleted mapping for index ${name}`);
+      await this.deleteIndex(name);
 
       // Update index name on the class instance
-      index.name = nextIndexName;
+      this.indexes[alias].name = nextIndexName;
     }
   }
 
@@ -199,9 +227,10 @@ export class Elastic {
   }
 
   private getIndexNameFromAlias(indexAlias: string): string {
-    for (const index of this.indexes) {
-      if (index.alias === indexAlias) {
-        return index.name;
+    const aliases = Object.keys(this.indexes);
+    for (const alias of aliases) {
+      if (alias === indexAlias) {
+        return this.indexes[alias].name;
       }
     }
 
@@ -212,7 +241,7 @@ export class Elastic {
   // Note that this creates the index if it doesn't exist too
   // https://www.elastic.co/guide/en/elasticsearch/reference/7.16/docs-bulk.html
   async bulkIndexFromMap(indexAlias: string, map: EsBulkData): Promise<any> {
-    await this.fetchIndexNames();
+    await this.fetchIndexName(indexAlias);
 
     const indexName = this.getIndexNameFromAlias(indexAlias);
     const indexExisted = await this.doesIndexExist(indexName);
@@ -238,12 +267,7 @@ export class Elastic {
     // If the index didn't exist, then we need to realias it.
     // If it did exist, it is already associated with an alias
     if (!indexExisted) {
-      macros.log(`Aliasing index ${indexName} as ${indexAlias}`);
-      await client.indices.putAlias({
-        index: indexName,
-        name: indexAlias,
-      });
-      macros.log(`Aliased index ${indexName} as ${indexAlias}`);
+      await this.createAlias(indexName, indexAlias);
     }
   }
 

--- a/utils/elastic.ts
+++ b/utils/elastic.ts
@@ -5,8 +5,8 @@
  */
 
 import { Client } from "@elastic/elasticsearch";
-import _, { map } from "lodash";
 import pMap from "p-map";
+import _ from "lodash";
 import macros from "./macros";
 import {
   EsBulkData,
@@ -89,42 +89,35 @@ export class Elastic {
 
   async createIndex(indexName: string, mapping): Promise<void> {
     macros.log(`Creating index ${indexName}`);
-    await client.indices
-      .create({
-        index: indexName,
-        body: mapping,
-      })
-      .then(() => {
-        macros.log(`Created index ${indexName}`);
-      })
-      .catch((e) => macros.log(`Error creating index ${indexName}: ${e}`));
+    try {
+      await client.indices.create({ index: indexName, body: mapping });
+      macros.log(`Created index ${indexName}`);
+    } catch (e) {
+      macros.log(`Error creating index ${indexName}: ${e}`);
+      throw e;
+    }
   }
 
   async deleteIndex(indexName: string): Promise<void> {
     macros.log(`Deleting index ${indexName}`);
-    await client.indices
-      .delete({
-        index: indexName,
-      })
-      .then(() => {
-        macros.log(`Deleted index ${indexName}`);
-      })
-      .catch((e) => macros.log(`Error deleting index ${indexName}: ${e}`));
+    try {
+      await client.indices.delete({ index: indexName });
+      macros.log(`Deleted index ${indexName}`);
+    } catch (e) {
+      macros.log(`Error deleting index ${indexName}: ${e}`);
+      throw e;
+    }
   }
 
   async createAlias(indexName: string, aliasName: string): Promise<void> {
     macros.log(`Aliasing index ${indexName} as ${aliasName}`);
-    await client.indices
-      .putAlias({
-        index: indexName,
-        name: aliasName,
-      })
-      .then(() => {
-        macros.log(`Aliased index ${indexName} as ${aliasName}`);
-      })
-      .catch((e) =>
-        macros.log(`Error aliasing ${indexName} as ${aliasName}: ${e}`)
-      );
+    try {
+      await client.indices.putAlias({ index: indexName, name: aliasName });
+      macros.log(`Aliased index ${indexName} as ${aliasName}`);
+    } catch (e) {
+      macros.log(`Error aliasing ${indexName} as ${aliasName}: ${e}`);
+      throw e;
+    }
   }
 
   // replace an index with a fresh one with a specified mapping


### PR DESCRIPTION
- Fixes an issue with the updater and elastic client where initial setup of indices was not occurring. Now, any bulk upsert will first check the existence of any blue/green index, and create them when necessary.
- Abstracts the naming and mapping of the index away from all business logic on elastic.ts so it only resides in the constructor (in case we need a future edit to indices as a whole)
-  Cleans up some more of `elastic.ts`