### PR TITLE
Fix notification server health check

### DIFF
--- a/twilio/server.ts
+++ b/twilio/server.ts
@@ -21,7 +21,7 @@ server.listen(port, () => {
   console.log("Running twilio notification server on port %s", port);
 });
 
-app.get("/knockknock", (req, res) => res.send("Who's there?"));
+app.get("/knockknock", (req, res) => res.status(200).send("Who's there?"));
 
 app.post("/twilio/sms", (req, res) => twilioNotifyer.handleUserReply(req, res));
 


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

Prod webserver keeps dying because it fails health checks. For some reason, on prod the notification server healthcheck status code is 304 while on staging it's sometimes 200 sometimes 304. This PR explicitly sets the status code to always be 200.

<br>

# Tickets

###### A link to any tickets this PR is associated with on Trello.

-

# Contributors

###### Anyone who contributed to this PR for future reference.

-

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

-
-
-

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
