### PR TITLE
Temp Prisma fix

### DIFF
--- a/services/prisma.ts
+++ b/services/prisma.ts
@@ -1,14 +1,15 @@
 import { PrismaClient } from "@prisma/client";
-import macros from "../utils/macros";
 
-macros.log("** Creating Prisma client");
 let prisma: PrismaClient;
 try {
   prisma = new PrismaClient({
     log: ["info", "warn", "error"],
   });
 } catch (e) {
-  macros.error(e);
+  // See github pull #91 for more info
+  // Basically, we need to be able to kill Prisma in our Macros class
+  // So, we can't use Macros in this file, since this file is a dependency for Macros, and that creates a circular dependency
+  console.error(e);
 }
 
 export default prisma;

--- a/utils/macros.ts
+++ b/utils/macros.ts
@@ -347,6 +347,7 @@ class Macros extends commonMacros {
       // If running on Travis, just exit 1 and travis will send off an email.
       if (process.env.CI) {
         process.exit(1);
+
         // If running on AWS, tell rollbar about the error so rollbar sends off an email.
       } else {
         const err_string = JSON.stringify(args);

--- a/utils/macros.ts
+++ b/utils/macros.ts
@@ -15,6 +15,7 @@ import { AmplitudeEvent } from "../types/requestTypes";
 import "colors";
 import { createLogger, format, transports } from "winston";
 import "winston-daily-rotate-file";
+import prisma from "../services/prisma";
 
 dotenv.config();
 
@@ -338,7 +339,7 @@ class Macros extends commonMacros {
     Macros.logger.error(args);
 
     super.error(
-      "Consider using the LOG_LEVEL environment variable to see more\nValid options are VERBOSE, HTTP, and INFO (default)\n",
+      "Consider using the LOG_LEVEL environment variable to see more - valid options are VERBOSE, HTTP, and INFO (default)",
       ...args
     );
 
@@ -346,9 +347,20 @@ class Macros extends commonMacros {
       // If running on Travis, just exit 1 and travis will send off an email.
       if (process.env.CI) {
         process.exit(1);
-
         // If running on AWS, tell rollbar about the error so rollbar sends off an email.
       } else {
+        const err_string = JSON.stringify(args);
+        // TEMP / TODO - REMOVE / DO NOT LEAVE HERE PLEASE
+        // Temp fix to address Prisma connection pool issues
+        // https://github.com/prisma/prisma/issues/7249#issuecomment-1059719644
+        if (
+          err_string.includes("P2024") ||
+          err_string.includes(
+            "Timed out fetching a new connection from the connection pool"
+          )
+        ) {
+          prisma.$disconnect;
+        }
         this.logRollbarError(args, false);
       }
     }


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>

This is going to be the main Prisma bugfix PR. I'm detailing the history, research, and random stuff here. 

### What
Prisma connection pool is acting up. This has happened before (see [this error from June 2021](
https://rollbar.com/ryanhugh/searchneu/items/3868/)), but I think we had other issues covering it up, so we didn't notice

Other Rollbar issues:
- https://rollbar.com/ryanhugh/searchneu/items/3868/
- https://rollbar.com/ryanhugh/searchneu/items/3887/
- https://rollbar.com/ryanhugh/searchneu/items/3958/

### RCA
This is unexpected Prisma behavior. Normally, when the connection pool is full, the queries just die until the pool clears up. In our case, it never recovers from this state. 

Two related issues on GitHub:
- https://github.com/prisma/prisma/issues/7249
- https://github.com/prisma/prisma/issues/11868

### Why now?
I think we see this issue much more often now for two reasons:
- Megan fixed the updater to die properly, so now the issue is more visible
- The list of term IDs on our homepage is loaded dynamically, so every time someone visits the page, a Prisma query is triggered. I think this is the main reason

### Temp Fix
Calling `prisma.$disconnect()` forcibly restarts the connection pool. 

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- https://trello.com/c/Kx93LHkv/276-fix-updater-dying-in-prod

# Contributors

###### Anyone who contributed to this PR for future reference.

- @hankewyczz 

# Checklist

- [x] Filled out PR template :wink:
- [ ] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
