### PR TITLE
add phrase searching to searcher

### DIFF
--- a/services/searcher.ts
+++ b/services/searcher.ts
@@ -292,11 +292,6 @@ class Searcher {
       fieldQuery = matchQueries[1][0];
     }
 
-    //if there was an empty search, match_all
-    if (phraseQueries.length === 0 && !fieldQExists) {
-      phraseQueries.push(MATCH_ALL_QUERY);
-    }
-
     // use lower classId has tiebreaker after relevance
     const sortByClassId: SortInfo = {
       "class.classId.keyword": { order: "asc", unmapped_type: "keyword" },
@@ -335,7 +330,10 @@ class Searcher {
       sort: ["_score", sortByClassId],
       query: {
         bool: {
-          must: phraseQueries, //must match all the phrases
+          must:
+            phraseQueries.length === 0 && !fieldQExists
+              ? MATCH_ALL_QUERY
+              : phraseQueries,
           filter: {
             bool: {
               should: [

--- a/services/searcher.ts
+++ b/services/searcher.ts
@@ -225,7 +225,7 @@ class Searcher {
   parseQuery(query: string): QueryWithType[] {
     const ret = [];
     let curString = "";
-    let isPhrase: boolean = false;
+    let isPhrase = false;
 
     for (let i = 0; i < query.length; i++) {
       //if we find a quote, we want to make the correct query and push it onto the return list
@@ -279,11 +279,11 @@ class Searcher {
     let fieldQuery: LeafQuery;
 
     //are there any field Queries?
-    let fieldQExists: boolean = false;
+    let fieldQExists = false;
 
     //the current fields string, we want to build a single query with all
     //the terms that are not phrases.
-    let fieldStr: string = "";
+    let fieldStr = "";
     for (let i = 0; i < queryArr.length; ++i) {
       //if the type is phrase, add a phrase query with the term
       if (queryArr[i].type === "phrase") {

--- a/services/searcher.ts
+++ b/services/searcher.ts
@@ -235,7 +235,7 @@ class Searcher {
     const re = new RegExp(matches.join("|"), "gi");
     const non_matches = query.replace(re, "").replace('"', "");
 
-    let phraseQueries = [];
+    const phraseQueries = [];
 
     // go through the phrases, and make phrase queries with them.
     for (let i = 0; i < matches.length; ++i) {
@@ -251,7 +251,7 @@ class Searcher {
     queries.push(phraseQueries);
 
     //make the field query and add it to the list.
-    let fieldQuery = [];
+    const fieldQuery = [];
     if (non_matches.trim() !== "") {
       fieldQuery.push({
         multi_match: {
@@ -284,7 +284,7 @@ class Searcher {
 
     const phraseQueries: LeafQuery[] = matchQueries[0];
     let fieldQuery: LeafQuery;
-    let fieldQExists: boolean = false;
+    let fieldQExists = false;
 
     if (matchQueries[1].length !== 0) {
       fieldQExists = true;

--- a/services/searcher.ts
+++ b/services/searcher.ts
@@ -223,8 +223,6 @@ class Searcher {
    * @returns an object containing a list of phrase_queries, and a field query.
    */
   parseQuery(query: string): ParsedQuery {
-    const queries = {};
-
     let matches = query.match(/"(.*?)"/gi);
     //if there are no phrases, then make matches an empty list instead of being null
     if (matches === null) {
@@ -281,15 +279,13 @@ class Searcher {
     max: number,
     aggregation = ""
   ): EsQuery {
-    const fields: string[] = this.getFields();
-
     //a list of all queries
     const matchQueries: ParsedQuery = this.parseQuery(query);
 
     const phraseQueries: LeafQuery[] = matchQueries.phraseQ;
 
     const fieldQuery: LeafQuery = matchQueries.fieldQ;
-    let fieldQExists = fieldQuery !== null;
+    const fieldQExists = fieldQuery !== null;
 
     // use lower classId has tiebreaker after relevance
     const sortByClassId: SortInfo = {

--- a/tests/__snapshots__/search.test.seq.ts.snap
+++ b/tests/__snapshots__/search.test.seq.ts.snap
@@ -37,7 +37,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -109,7 +111,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -181,7 +185,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -253,7 +259,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -322,7 +330,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -389,7 +399,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -458,7 +470,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -527,7 +541,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -596,7 +612,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -665,7 +683,9 @@ Array [
             ],
           },
         },
-        "must": Object {
+        "minimum_should_match": 0,
+        "must": Array [],
+        "should": Object {
           "multi_match": Object {
             "fields": Array [
               "class.name^2",
@@ -738,7 +758,9 @@ Object {
           ],
         },
       },
-      "must": Object {
+      "minimum_should_match": 0,
+      "must": Array [],
+      "should": Object {
         "multi_match": Object {
           "fields": Array [
             "class.name^2",

--- a/tests/search.test.seq.ts
+++ b/tests/search.test.seq.ts
@@ -1,6 +1,6 @@
 import searcher from "../services/searcher";
 import prisma from "../services/prisma";
-import { LeafQuery, MultiMatchQuery, ParsedQuery } from "../types/searchTypes";
+import { LeafQuery, ParsedQuery } from "../types/searchTypes";
 
 beforeAll(async () => {
   searcher.subjects = {};
@@ -26,12 +26,12 @@ describe("searcher", () => {
   //Unit tests for the parseQuery function
   describe("parseQuery", () => {
     it("query with no phrases", () => {
-      let retQueries: ParsedQuery = searcher.parseQuery(
+      const retQueries: ParsedQuery = searcher.parseQuery(
         "this is a query with no phrases"
       );
       expect(retQueries.phraseQ.length).toEqual(0); //no phrase queries
       expect(retQueries.fieldQ).not.toEqual(null);
-      let fieldQuery: LeafQuery = retQueries.fieldQ;
+      const fieldQuery: LeafQuery = retQueries.fieldQ;
 
       expect(fieldQuery).toEqual({
         multi_match: {
@@ -43,12 +43,12 @@ describe("searcher", () => {
     });
 
     it("query with just a phrase", () => {
-      let retQueries: ParsedQuery = searcher.parseQuery('"this is a phrase"');
+      const retQueries: ParsedQuery = searcher.parseQuery('"this is a phrase"');
 
       expect(retQueries.phraseQ.length).toEqual(1);
       expect(retQueries.fieldQ).toEqual(null);
 
-      let phraseQuery: LeafQuery = retQueries.phraseQ[0];
+      const phraseQuery: LeafQuery = retQueries.phraseQ[0];
 
       expect(phraseQuery).toEqual({
         multi_match: {
@@ -60,12 +60,12 @@ describe("searcher", () => {
     });
 
     it("query with a phrase and other text", () => {
-      let retQueries: ParsedQuery = searcher.parseQuery('text "phrase" text');
+      const retQueries: ParsedQuery = searcher.parseQuery('text "phrase" text');
       expect(retQueries.phraseQ.length).toEqual(1);
       expect(retQueries.fieldQ).not.toEqual(null);
 
-      let phraseQuery: LeafQuery = retQueries.phraseQ[0];
-      let fieldQuery: LeafQuery = retQueries.fieldQ;
+      const phraseQuery: LeafQuery = retQueries.phraseQ[0];
+      const fieldQuery: LeafQuery = retQueries.fieldQ;
 
       expect(phraseQuery).toEqual({
         multi_match: {

--- a/tests/search.test.seq.ts
+++ b/tests/search.test.seq.ts
@@ -1,5 +1,6 @@
 import searcher from "../services/searcher";
 import prisma from "../services/prisma";
+import { LeafQuery, MultiMatchQuery, ParsedQuery } from "../types/searchTypes";
 
 beforeAll(async () => {
   searcher.subjects = {};
@@ -22,6 +23,67 @@ describe("searcher", () => {
     });
   });
 
+  //Unit tests for the parseQuery function
+  describe("parseQuery", () => {
+    it("query with no phrases", () => {
+      let retQueries: ParsedQuery = searcher.parseQuery(
+        "this is a query with no phrases"
+      );
+      expect(retQueries.phraseQ.length).toEqual(0); //no phrase queries
+      expect(retQueries.fieldQ).not.toEqual(null);
+      let fieldQuery: LeafQuery = retQueries.fieldQ;
+
+      expect(fieldQuery).toEqual({
+        multi_match: {
+          query: "this is a query with no phrases",
+          type: "most_fields",
+          fields: searcher.getFields(),
+        },
+      });
+    });
+
+    it("query with just a phrase", () => {
+      let retQueries: ParsedQuery = searcher.parseQuery('"this is a phrase"');
+
+      expect(retQueries.phraseQ.length).toEqual(1);
+      expect(retQueries.fieldQ).toEqual(null);
+
+      let phraseQuery: LeafQuery = retQueries.phraseQ[0];
+
+      expect(phraseQuery).toEqual({
+        multi_match: {
+          query: "this is a phrase",
+          type: "phrase",
+          fields: searcher.getFields(),
+        },
+      });
+    });
+
+    it("query with a phrase and other text", () => {
+      let retQueries: ParsedQuery = searcher.parseQuery('text "phrase" text');
+      expect(retQueries.phraseQ.length).toEqual(1);
+      expect(retQueries.fieldQ).not.toEqual(null);
+
+      let phraseQuery: LeafQuery = retQueries.phraseQ[0];
+      let fieldQuery: LeafQuery = retQueries.fieldQ;
+
+      expect(phraseQuery).toEqual({
+        multi_match: {
+          query: "phrase",
+          type: "phrase",
+          fields: searcher.getFields(),
+        },
+      });
+
+      expect(fieldQuery).toEqual({
+        multi_match: {
+          query: "text text",
+          type: "most_fields",
+          fields: searcher.getFields(),
+        },
+      });
+    });
+  });
   // TODO: create an association between cols in elasticCourseSerializer and here
   describe("generateQuery", () => {
     it("generates match_all when no query", () => {

--- a/types/searchTypes.ts
+++ b/types/searchTypes.ts
@@ -34,7 +34,8 @@ export type LeafQuery =
   | ExistsQuery
   | MultiMatchQuery
   | RangeQuery
-  | MatchAllQuery;
+  | MatchAllQuery
+  | BoolQuery;
 
 export interface TermQuery {
   term: FieldQuery;
@@ -61,6 +62,11 @@ export interface RangeQuery {
       lt?: number;
     };
   };
+}
+
+export interface QueryWithType {
+  query: string;
+  type: "phrase" | "most_fields";
 }
 
 export const MATCH_ALL_QUERY = { match_all: {} };
@@ -92,6 +98,7 @@ export interface MustQuery {
 
 export interface ShouldQuery {
   should: OneOrMany<QueryNode>;
+  minimum_should_match?: number;
 }
 
 export interface FilterQuery {

--- a/types/searchTypes.ts
+++ b/types/searchTypes.ts
@@ -64,9 +64,9 @@ export interface RangeQuery {
   };
 }
 
-export interface QueryWithType {
-  query: string;
-  type: "phrase" | "most_fields";
+export interface ParsedQuery {
+  phraseQ: LeafQuery[];
+  fieldQ: LeafQuery;
 }
 
 export const MATCH_ALL_QUERY = { match_all: {} };


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.
Added the capabilities for phrase searching to the project. If a query has a phrase within quotes, the searcher will search using a match_phrase query. Every result must contain the contents of a phrase. 

To replicate locally, run yarn dev on the backend, and yarn dev:fullstack on the front end. You can search data structures, and see that discrete structures comes before it. If you search "data structures", it'll be the only result on the page. 
<br> 

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- https://trello.com/c/lYrJEVja/269-add-phrase-searching

# Contributors

###### Anyone who contributed to this PR for future reference.

- @sebwittr 
- @andrewydai 

# Feature List

###### A list of more in-depth and technical changes, additions, deletions, and fixes this PR provides.

- Added a parser function to the searcher, which broke down queries to phrase queries and non-phrase queries
- Created a QueryWithType type, which was either "phrase" or "most_fields".
- New query structure requires result to include phrase, and should have any other terms.

# Notes

###### A list of miscellaneous notes for this pull request, such as whether we need to add something later for production, or that it was time boxed, etc.

<br>

# Checklist

- [x] Filled out PR template :wink:
- [ ] Approved by designers
- [x] Is passing linting checks
- [ ] Is passing tsc
- [ ] Is passing existing tests
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
