### PR TITLE
Tweaks to fix staging employee insertion

### DIFF
--- a/scrapers/employees/employees.ts
+++ b/scrapers/employees/employees.ts
@@ -21,7 +21,7 @@ function employeeQuery(query: string): unknown {
   // inspect the API response at the above link & update accordingly
   return {
     versionInfo: {
-      moduleVersion: "HkL1qOMsAyyecvGQd_lOfQ",
+      moduleVersion: "mWWAP+YL9U4e9B2D7spGFQ",
       apiVersion: "ad_141F5PYcK3c+D5K8O+g",
     },
     viewName: "MainFlow.FacultyAndStaffDirectory",

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -130,10 +130,12 @@ class DumpProcessor {
 
     // We delete all of the professors, and insert anew
     // This gets rid of any stale entries (ie. former employees), since each scrape gets ALL employees (not just current term).
-    await prisma.professor.deleteMany({});
-    await prisma.professor.createMany({
-      data: profDump.map((prof) => this.processProf(prof)),
-    });
+    if (profDump.length > 1) {
+      await prisma.professor.createMany({
+        data: profDump.map((prof) => this.processProf(prof)),
+      });
+      await prisma.professor.deleteMany({});
+    }
 
     macros.log("DumpProcessor: finished with profs");
 

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -332,6 +332,7 @@ class DumpProcessor {
       "title",
       "interests",
       "officeStreetAddress",
+      "office",
     ]) as Prisma.ProfessorCreateInput;
   }
 

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -131,10 +131,10 @@ class DumpProcessor {
     // We delete all of the professors, and insert anew
     // This gets rid of any stale entries (ie. former employees), since each scrape gets ALL employees (not just current term).
     if (profDump.length > 1) {
+      await prisma.professor.deleteMany({});
       await prisma.professor.createMany({
         data: profDump.map((prof) => this.processProf(prof)),
       });
-      await prisma.professor.deleteMany({});
     }
 
     macros.log("DumpProcessor: finished with profs");


### PR DESCRIPTION
3 issues:

- Update the `moduleVersion`
- Don't delete professors if prodDump is empty (ie. when the updater runs)
- Exclude the `office` key, which exists in some of our old employee data