### PR TITLE
Remove direct PSQL calls

### DIFF
--- a/graphql/resolvers/termInfo.ts
+++ b/graphql/resolvers/termInfo.ts
@@ -1,11 +1,47 @@
 import prisma from "../../services/prisma";
 import { TermInfo } from "../../types/types";
 
+type TermInfoCache = Record<
+  string,
+  {
+    termInfos: TermInfo[];
+    lastUpdated: number;
+  }
+>;
+
+const TERM_INFO_CACHE: TermInfoCache = {};
+
+// How long should it take for the cache to be declared stale and re-fetched? 2 hours
+const CACHE_REFRESH_INTERVAL = 2 * 60 * 60 * 1000;
+
+// Checks if the cache is valid, or if it's time to revalidate and fetch from the database
+function isCacheValid(subCollege: string): boolean {
+  if (subCollege in TERM_INFO_CACHE) {
+    return (
+      TERM_INFO_CACHE[subCollege].lastUpdated + CACHE_REFRESH_INTERVAL >
+      Date.now()
+    );
+  }
+  return false;
+}
+
 const getTermInfos = async (subCollege: string): Promise<TermInfo[]> => {
-  return await prisma.termInfo.findMany({
-    where: { subCollege: subCollege },
-    orderBy: { termId: "desc" },
-  });
+  if (isCacheValid(subCollege)) {
+    return TERM_INFO_CACHE[subCollege].termInfos;
+  } else {
+    // Cache is invalid (or doesn't exist yet), so we fetch from the database and cache it
+    const termInfos = await prisma.termInfo.findMany({
+      where: { subCollege: subCollege },
+      orderBy: { termId: "desc" },
+    });
+
+    TERM_INFO_CACHE[subCollege] = {
+      termInfos,
+      lastUpdated: Date.now(),
+    };
+
+    return termInfos;
+  }
 };
 
 const resolvers = {

--- a/graphql/resolvers/termInfo.ts
+++ b/graphql/resolvers/termInfo.ts
@@ -9,9 +9,17 @@ type TermInfoCache = Record<
   }
 >;
 
+/**
+ * This mechanism caches the list of terms for each subcollege.
+ * This list is only updated when new semesters are released (ie. 2-4 times a year)
+ *
+ * Every time a user first loads the SearchNEU page, they need to know which semesters are available. It makes no
+ *  sense to query Postgres every time - this isn't a scalable method, as Prisma (and psql) limit the number of connections.
+ * Instead, we can cache the list of terms, only updating it every once in a while (and not on a user-by-user basis)
+ */
 const TERM_INFO_CACHE: TermInfoCache = {};
 
-// How long should it take for the cache to be declared stale and re-fetched? 2 hours
+// How long should it take for the cache to be declared stale and re-fetched, in ms? (currently 2 hours)
 const CACHE_REFRESH_INTERVAL = 2 * 60 * 60 * 1000;
 
 // Checks if the cache is valid, or if it's time to revalidate and fetch from the database

--- a/tests/end_to_end/search.test.git.ts
+++ b/tests/end_to_end/search.test.git.ts
@@ -24,10 +24,11 @@ describe("Searching for courses", () => {
               }
           `);
 
-      expect(
-        "Fundamentals of Computer Science 1" in
-          (res.data?.search.nodes || []).map((node) => node.name)
-      ).toBeTruthy();
+      const result = res.data?.search.nodes || [];
+      const names = result.map((node) => node.names);
+      console.log(names);
+
+      expect("Fundamentals of Computer Science 1" in names).toBeTruthy();
     }
   });
 

--- a/tests/end_to_end/search.test.git.ts
+++ b/tests/end_to_end/search.test.git.ts
@@ -9,18 +9,25 @@ async function query(q: DocumentNode): Promise<GraphQLResponse> {
 
 describe("Searching for courses", () => {
   // https://trello.com/c/AFcdt4tt/106-display-one-search-result-with-a-course-code
-  test("searching for a single course only returns one result", async () => {
+  test("searching for a single course returns it as a result", async () => {
     const queries = ["CS2500", "cs2500", "cs 2500", "CS 2500"];
     for (const q of queries) {
       const res = await query(gql`
             query {
                 search(termId: "202240", query: "${q}") {
-                  totalCount
+                  nodes {
+                    ... on ClassOccurrence {
+                      name
+                    }
+                  }
                 }
               }
           `);
 
-      expect(res.data?.search.totalCount).toBe(1);
+      expect(
+        "Fundamentals of Computer Science 1" in
+          (res.data?.search.nodes || []).map((node) => node.name)
+      ).toBeTruthy();
     }
   });
 
@@ -40,7 +47,7 @@ describe("Searching for courses", () => {
       }
     `);
 
-    const name = res.data.search.nodes[0].name;
+    const name = res.data?.search.nodes[0].name;
     expect(name).toMatch(/Fundamentals of Computer Science.*/);
   });
 });

--- a/tests/end_to_end/search.test.git.ts
+++ b/tests/end_to_end/search.test.git.ts
@@ -26,6 +26,7 @@ describe("Searching for courses", () => {
 
       const result = res.data?.search.nodes || [];
       const names = result.map((node) => node.name);
+      console.log(result);
       console.log(names);
 
       expect("Fundamentals of Computer Science 1" in names).toBeTruthy();

--- a/tests/end_to_end/search.test.git.ts
+++ b/tests/end_to_end/search.test.git.ts
@@ -26,10 +26,8 @@ describe("Searching for courses", () => {
 
       const result = res.data?.search.nodes || [];
       const names = result.map((node) => node.name);
-      console.log(result);
-      console.log(names);
 
-      expect("Fundamentals of Computer Science 1" in names).toBeTruthy();
+      expect(names.includes("Fundamentals of Computer Science 1")).toBeTruthy();
     }
   });
 

--- a/tests/end_to_end/search.test.git.ts
+++ b/tests/end_to_end/search.test.git.ts
@@ -25,7 +25,7 @@ describe("Searching for courses", () => {
           `);
 
       const result = res.data?.search.nodes || [];
-      const names = result.map((node) => node.names);
+      const names = result.map((node) => node.name);
       console.log(names);
 
       expect("Fundamentals of Computer Science 1" in names).toBeTruthy();

--- a/utils/abstractMacros.ts
+++ b/utils/abstractMacros.ts
@@ -70,13 +70,6 @@ class Macros {
     console.error("Error: ", ...fullArgs); // eslint-disable-line no-console
     console.trace(); // eslint-disable-line no-console
   }
-
-  // https://stackoverflow.com/questions/18082/validate-decimal-numbers-in-javascript-isnumeric
-  static isNumeric(n: string): boolean {
-    return (
-      !Number.isNaN(Number.parseFloat(n)) && Number.isFinite(Number.parseInt(n))
-    );
-  }
 }
 
 // Set up the Macros.TEST, Macros.DEV, and Macros.PROD based on some env variables.


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>

- Good news: SearchNEU is popular, widely used, and sees a significant jump in usage as students return to classes.
- Bad news: Prisma can only handle 15 simultaneous connections.

We make direct Prisma calls in two cases:
- when fetching the semester information (ie. on every single page onload)
- when searching for a specific single class (eg. "CS3500")

This isn't scalable - we need to reduce our direct usage of Postgres (add caching/use elasticsearch)

This ticket removes them both 

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- N/A

# Contributors

###### Anyone who contributed to this PR for future reference.

- @hankewyczz 



# Checklist

- [x] Filled out PR template :wink:
- [x] Has documentation and comments in code
- [ ] Has test coverage for code
- [x] Will have clear squash commit message

<br>
@sandboxnu/searchneu
