### PR TITLE
Allow querying for classes in bulk

### DIFF
--- a/graphql/resolvers/class.ts
+++ b/graphql/resolvers/class.ts
@@ -21,12 +21,26 @@ const getLatestClassOccurrence = async (
   subject: string,
   classId: string
 ): Promise<Course> => {
-  const results: PrismaCourse[] = await prisma.course.findMany({
+  const results: PrismaCourse = await prisma.course.findFirst({
     where: { subject, classId },
     include: { sections: true },
     orderBy: { termId: "desc" },
   });
-  return serializeValues(results)[0];
+  return serializeValues([results])[0];
+};
+
+const getBulkClassOccurrences = async (
+  input: Array<{
+    subject: string;
+    classId: string;
+  }>
+): Promise<Course[]> => {
+  const results: PrismaCourse[] = await prisma.course.findMany({
+    where: { OR: input },
+    orderBy: { termId: "desc" },
+    distinct: ["classId", "subject"],
+  });
+  return serializeValues(results);
 };
 
 const getAllClassOccurrences = async (
@@ -78,10 +92,10 @@ const getSectionById = async (id: string): Promise<Section> => {
 const resolvers = {
   Query: {
     class: (parent, args) => {
-      return getLatestClassOccurrence(
-        args.subject,
-        args.classId && args.classId
-      );
+      return getLatestClassOccurrence(args.subject, args.classId);
+    },
+    bulkClass: (parent, args) => {
+      return getBulkClassOccurrences(args.input);
     },
     classByHash: (parent, args) => {
       return getClassOccurrenceById(args.hash);

--- a/graphql/resolvers/class.ts
+++ b/graphql/resolvers/class.ts
@@ -94,7 +94,7 @@ const resolvers = {
     class: (parent, args) => {
       return getLatestClassOccurrence(args.subject, args.classId);
     },
-    bulkClass: (parent, args) => {
+    bulkClasses: (parent, args) => {
       return getBulkClassOccurrences(args.input);
     },
     classByHash: (parent, args) => {

--- a/graphql/tests/__snapshots__/class.test.seq.ts.snap
+++ b/graphql/tests/__snapshots__/class.test.seq.ts.snap
@@ -1,5 +1,37 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`class query can query in bulk 1`] = `
+Object {
+  "data": Object {
+    "bulkClasses": Array [
+      Object {
+        "classId": "3500",
+        "latestOccurrence": Object {
+          "termId": "201930",
+        },
+        "name": "OOD",
+        "subject": "CS",
+      },
+      Object {
+        "classId": "2500",
+        "latestOccurrence": Object {
+          "termId": "201930",
+        },
+        "name": "Fundamentals of Computer Science 1",
+        "subject": "CS",
+      },
+    ],
+  },
+  "errors": undefined,
+  "extensions": undefined,
+  "http": Object {
+    "headers": Headers {
+      Symbol(map): Object {},
+    },
+  },
+}
+`;
+
 exports[`class query gets all occurrences 1`] = `
 Object {
   "data": Object {

--- a/graphql/tests/class.test.seq.ts
+++ b/graphql/tests/class.test.seq.ts
@@ -14,6 +14,18 @@ beforeAll(async () => {
   await prisma.course.deleteMany({});
   await prisma.course.create({
     data: {
+      id: "neu.edu/201930/CS/3500",
+      host: "neu.edu",
+      termId: "201930",
+      subject: "CS",
+      classId: "3500",
+      name: "OOD",
+      lastUpdateTime: new Date(),
+    },
+  });
+
+  await prisma.course.create({
+    data: {
       id: "neu.edu/201930/CS/2500",
       host: "neu.edu",
       termId: "201930",
@@ -50,6 +62,29 @@ beforeAll(async () => {
   });
 });
 describe("class query", () => {
+  it("can query in bulk", async () => {
+    const res = await query({
+      query: gql`
+        query class {
+          bulkClasses(
+            input: [
+              { subject: "CS", classId: "3500" }
+              { subject: "CS", classId: "2500" }
+            ]
+          ) {
+            subject
+            classId
+            name
+            latestOccurrence {
+              termId
+            }
+          }
+        }
+      `,
+    });
+    expect(res).toMatchSnapshot();
+  });
+
   it("gets all occurrences", async () => {
     const res = await query({
       query: gql`

--- a/graphql/typeDefs/class.js
+++ b/graphql/typeDefs/class.js
@@ -3,8 +3,14 @@ import { gql } from "apollo-server";
 const typeDef = gql`
   extend type Query {
     class(subject: String!, classId: String!): Class
+    bulkClass(input: [BulkClassInput!]!): [Class!]
     classByHash(hash: String!): ClassOccurrence
     sectionByHash(hash: String!): Section
+  }
+
+  input BulkClassInput {
+    subject: String!
+    classId: String!
   }
 
   type Class {

--- a/graphql/typeDefs/class.js
+++ b/graphql/typeDefs/class.js
@@ -3,7 +3,7 @@ import { gql } from "apollo-server";
 const typeDef = gql`
   extend type Query {
     class(subject: String!, classId: String!): Class
-    bulkClass(input: [BulkClassInput!]!): [Class!]
+    bulkClasses(input: [BulkClassInput!]!): [Class!]
     classByHash(hash: String!): ClassOccurrence
     sectionByHash(hash: String!): Section
   }


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>

Adds a `bulkClasses` query to the course-catalog-api. Requested by the Graduate team [(see here)](https://github.com/sandboxnu/graduatenu/issues/472)

```gql
query Query {
  bulkClasses(input: [{ subject: "CS", classId: "3000"}, {subject: "CS", classId: "2500"}]) {
    name
    classId
    subject
    latestOccurrence {
      termId
    }
  }
}
```
will return
```json
{
  "data": {
    "bulkClasses": [
      {
        "name": "Fundamentals of Computer Science 1",
        "classId": "2500",
        "subject": "CS",
        "latestOccurrence": {
          "termId": "202310"
        }
      },
      {
        "name": "Algorithms and Data",
        "classId": "3000",
        "subject": "CS",
        "latestOccurrence": {
          "termId": "202310"
        }
      }
    ]
  }
}
```

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- N/A

# Contributors

###### Anyone who contributed to this PR for future reference.

- @hankewyczz 



# Checklist

- [x] Filled out PR template :wink:
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

