### PR TITLE
Patch updater crashing for term ID `202225`

### DIFF
--- a/services/updater.ts
+++ b/services/updater.ts
@@ -17,6 +17,8 @@ import { NotificationInfo } from "../types/notifTypes";
 
 import { NUMBER_OF_TERMS_TO_UPDATE } from "../scrapers/classes/parsersxe/bannerv9Parser";
 
+const FAULTY_TERM_IDS = ["202225"];
+
 // ======= TYPES ======== //
 // A collection of structs for simpler querying of pre-scrape data
 interface OldData {
@@ -51,7 +53,17 @@ class Updater {
   constructor(termIds: string[]) {
     this.COURSE_MODEL = "course";
     this.SECTION_MODEL = "section";
-    this.SEMS_TO_UPDATE = termIds;
+    this.SEMS_TO_UPDATE = Updater.filterTermIds(termIds);
+  }
+
+  /**
+   * Filters the Banner term IDs that are given.
+   * Some terms (specifically, 202225) exist in Banner - but not fully.
+   * So, we get this term ID from the Banner endpoint which lists term IDs, but
+   * this will throw an error eventually (since this term has no sections associated with it in Banner).
+   */
+  static filterTermIds(termIds: string[]): string[] {
+    return termIds.filter((t) => FAULTY_TERM_IDS.includes(t));
   }
 
   // TODO must call this in server


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>
For some reason, the term with ID `202225` exists in a weird state in Banner:
- It is on the list of term IDs
- However, there are no sections associated with this term ID
  - As a result - when we call the Banner endpoint to get a term's sections, Banner throws an error
  - To mitigate this, we'll just filter this term out when updating. It's a past term anyways, so these classes/sections aren't changing anyways. 

# Checklist

- [x] Filled out PR template :wink:
- [ ] Has documentation and comments in code
- [ ] Has test coverage for code
- [ ] Will have clear squash commit message

<br>
@sandboxnu/searchneu
