### PR TITLE
Update Terraform behavior to properly forward notification server traffic

### DIFF
--- a/infrastructure/terraform/modules/course-catalog-api/domain.tf
+++ b/infrastructure/terraform/modules/course-catalog-api/domain.tf
@@ -1,8 +1,8 @@
 # domain record
 resource "cloudflare_record" "cname" {
-  count = length(var.domains)
+  count = length([var.api_domain, var.notifs_domain])
   zone_id = var.cloudflare_zone_id
-  name = var.domains[count.index]
+  name = [var.api_domain, var.notifs_domain][count.index]
   type = "CNAME"
   value = var.alb_dns_name
   proxied = true
@@ -19,7 +19,7 @@ resource "aws_lb_listener_rule" "host_based" {
 
   condition {
     host_header {
-      values = var.domains
+      values = [var.api_domain]
     }
   }
 }
@@ -35,7 +35,7 @@ resource "aws_lb_listener_rule" "notifs" {
 
   condition {
     host_header {
-      values = ["${module.label.stage == "staging" ? module.label.stage : ""}notifs.searchneu.com"]
+      values = [var.notifs_domain]
     }
   }
 }

--- a/infrastructure/terraform/modules/course-catalog-api/domain.tf
+++ b/infrastructure/terraform/modules/course-catalog-api/domain.tf
@@ -1,8 +1,8 @@
 # domain record
 resource "cloudflare_record" "cname" {
-  count = length([var.api_domain, var.notifs_domain])
+  for_each = toset([var.api_domain, var.notifs_domain])
   zone_id = var.cloudflare_zone_id
-  name = [var.api_domain, var.notifs_domain][count.index]
+  name = each.key
   type = "CNAME"
   value = var.alb_dns_name
   proxied = true

--- a/infrastructure/terraform/modules/course-catalog-api/variables.tf
+++ b/infrastructure/terraform/modules/course-catalog-api/variables.tf
@@ -33,11 +33,11 @@ variable "alb_dns_name" {
 }
 
 variable "api_domain" {
-  description = "domain for the API server"
+  description = "domain for the API server. ALB needs to already have certs for it"
 }
 
 variable "notifs_domain" {
-  description = "domain for the notification server"
+  description = "domain for the notification server. ALB needs to already have certs for it"
 }
 
 variable "cloudflare_zone_id" {

--- a/infrastructure/terraform/modules/course-catalog-api/variables.tf
+++ b/infrastructure/terraform/modules/course-catalog-api/variables.tf
@@ -32,8 +32,12 @@ variable "alb_dns_name" {
   description = "alb dns name to setup cname to"
 }
 
-variable "domains" {
-  description = "domains to put this env on. ALB needs to already have certs for it"
+variable "api_domain" {
+  description = "domain for the API server"
+}
+
+variable "notifs_domain" {
+  description = "domain for the notification server"
 }
 
 variable "cloudflare_zone_id" {

--- a/infrastructure/terraform/prod.tf
+++ b/infrastructure/terraform/prod.tf
@@ -10,7 +10,8 @@ module "prod" {
   alb_listener_arn     = module.alb.https_listener_arns[0]
   alb_sg_id            = aws_security_group.lb.id
   alb_dns_name         = module.alb.this_lb_dns_name
-  domains              = ["api.searchneu.com", "notifs.searchneu.com"] 
+  api_domain         = "api.searchneu.com"
+  notifs_domain      = "notifs.searchneu.com"
   cloudflare_zone_id   = var.cloudflare_zone_id
 
   ecr_url              = aws_ecr_repository.app.repository_url

--- a/infrastructure/terraform/staging.tf
+++ b/infrastructure/terraform/staging.tf
@@ -1,3 +1,8 @@
+locals {
+  api_domain         = "stagingapi.searchneu.com"
+  notifs_domain      = "stagingnotifs.searchneu.com"
+}
+
 module "staging" {
   source = "./modules/course-catalog-api"
 
@@ -11,9 +16,9 @@ module "staging" {
 
   alb_sg_id          = aws_security_group.lb.id
   alb_dns_name       = module.alb.this_lb_dns_name
-  api_domain         = "stagingapi.searchneu.com"
-  notifs_domain      = "stagingnotifs.searchneu.com"
-  domains            = [var.api_domain, var.notifs_domain] 
+  api_domain         = local.api_domain
+  notifs_domain      = local.notifs_domain
+  domains            = [local.api_domain, local.notifs_domain] 
   cloudflare_zone_id = var.cloudflare_zone_id
 
   ecr_url = aws_ecr_repository.app.repository_url

--- a/infrastructure/terraform/staging.tf
+++ b/infrastructure/terraform/staging.tf
@@ -11,7 +11,9 @@ module "staging" {
 
   alb_sg_id          = aws_security_group.lb.id
   alb_dns_name       = module.alb.this_lb_dns_name
-  domains            = ["stagingapi.searchneu.com", "stagingnotifs.searchneu.com"] 
+  api_domain         = "stagingapi.searchneu.com"
+  notifs_domain      = "stagingnotifs.searchneu.com"
+  domains            = [var.api_domain, var.notifs_domain] 
   cloudflare_zone_id = var.cloudflare_zone_id
 
   ecr_url = aws_ecr_repository.app.repository_url

--- a/infrastructure/terraform/staging.tf
+++ b/infrastructure/terraform/staging.tf
@@ -1,8 +1,3 @@
-locals {
-  api_domain         = "stagingapi.searchneu.com"
-  notifs_domain      = "stagingnotifs.searchneu.com"
-}
-
 module "staging" {
   source = "./modules/course-catalog-api"
 
@@ -16,9 +11,8 @@ module "staging" {
 
   alb_sg_id          = aws_security_group.lb.id
   alb_dns_name       = module.alb.this_lb_dns_name
-  api_domain         = local.api_domain
-  notifs_domain      = local.notifs_domain
-  domains            = [local.api_domain, local.notifs_domain] 
+  api_domain         = "stagingapi.searchneu.com"
+  notifs_domain      = "stagingnotifs.searchneu.com"
   cloudflare_zone_id = var.cloudflare_zone_id
 
   ecr_url = aws_ecr_repository.app.repository_url


### PR DESCRIPTION
# Purpose

###### A brief description of the purpose of the PR's changes for the project.

<br>

Update Terraform to properly forward data requests to the webserver. 

The webserver container in AWS deploys both the GraphQL API and the notifications server (on different ports). To forward them, we create rules based on the forwarding domain. 

So — `notifs.searchneu.com` should be forwarded to the notification server, and `api.searchneu.com` should be forwarded to the GraphQL API. 

We were having an issue with the staging notifications — the notifications were being forwarded to the GraphQL API.

The issue was with how our domains were declared in Terraform. @hankewyczz made changes to Terraform during the migration to ensure that `notifs.searchneu.com` was getting a Cloudflare cert (before that, this wasn't configured in Terraform). However, this had the side-effect of messing up the rule forwarding traffic. 

# Tickets

###### A link to any tickets this PR is associated with on Trello.

- N/A

# Contributors

###### Anyone who contributed to this PR for future reference.

- @hankewyczz 
- @soulwa 

<br>
@sandboxnu/searchneu
