### PR TITLE
Pp/mark past terms inactive

### DIFF
--- a/prisma/migrations/20230410043309_add_active_field_to_term_info_model/migration.sql
+++ b/prisma/migrations/20230410043309_add_active_field_to_term_info_model/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `active` to the `term_ids` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "term_ids" ADD COLUMN     "active" BOOLEAN NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -121,6 +121,7 @@ model TermInfo {
   termId     String @unique(map: "term_ids.term_id_unique") @map("term_id")
   subCollege String @map("sub_college")
   text       String
+  active     Boolean
 
   @@map("term_ids")
 }

--- a/scrapers/classes/parsersxe/termListParser.ts
+++ b/scrapers/classes/parsersxe/termListParser.ts
@@ -12,7 +12,7 @@ class TermListParser {
     const activeTermInfos = termsFromBanner.filter(
       (term) => !term.description.includes("View Only")
     );
-    const activeTermIds = activeTermInfos.map(t => t.code);
+    const activeTermIds = activeTermInfos.map((t) => t.code);
     const minActiveTermId = Math.min(...activeTermIds);
     return termsFromBanner.map((term) => {
       const subCollege = this.determineSubCollegeName(term.description);

--- a/scrapers/classes/parsersxe/termListParser.ts
+++ b/scrapers/classes/parsersxe/termListParser.ts
@@ -9,13 +9,11 @@ class TermListParser {
   serializeTermsList(
     termsFromBanner: { code: string; description: string }[]
   ): TermInfo[] {
-    const activeTerms = termsFromBanner.filter(
+    const activeTermInfos = termsFromBanner.filter(
       (term) => !term.description.includes("View Only")
     );
-    const minActiveCode = activeTerms.reduce((prev, cur) =>
-      prev.code < cur.code ? prev : cur
-    ).code;
-
+    const activeTermIds = activeTermInfos.map(t => t.code);
+    const minActiveTermId = Math.min(...activeTermIds);
     return termsFromBanner.map((term) => {
       const subCollege = this.determineSubCollegeName(term.description);
 

--- a/scrapers/classes/parsersxe/termListParser.ts
+++ b/scrapers/classes/parsersxe/termListParser.ts
@@ -9,6 +9,13 @@ class TermListParser {
   serializeTermsList(
     termsFromBanner: { code: string; description: string }[]
   ): TermInfo[] {
+    const activeTerms = termsFromBanner.filter(
+      (term) => !term.description.includes("View Only")
+    );
+    const minActiveCode = activeTerms.reduce((prev, cur) =>
+      prev.code < cur.code ? prev : cur
+    ).code;
+
     return termsFromBanner.map((term) => {
       const subCollege = this.determineSubCollegeName(term.description);
 
@@ -24,6 +31,7 @@ class TermListParser {
         termId: term.code,
         text: text,
         subCollege: subCollege,
+        active: term.code >= minActiveCode,
       };
     });
   }

--- a/scrapers/classes/parsersxe/termListParser.ts
+++ b/scrapers/classes/parsersxe/termListParser.ts
@@ -12,7 +12,7 @@ class TermListParser {
     const activeTermInfos = termsFromBanner.filter(
       (term) => !term.description.includes("View Only")
     );
-    const activeTermIds = activeTermInfos.map((t) => t.code);
+    const activeTermIds = activeTermInfos.map((t) => Number(t.code));
     const minActiveTermId = Math.min(...activeTermIds);
     return termsFromBanner.map((term) => {
       const subCollege = this.determineSubCollegeName(term.description);
@@ -29,7 +29,7 @@ class TermListParser {
         termId: term.code,
         text: text,
         subCollege: subCollege,
-        active: term.code >= minActiveCode,
+        active: Number(term.code) >= minActiveTermId,
       };
     });
   }

--- a/scrapers/classes/parsersxe/tests/__snapshots__/termListParser.test.js.snap
+++ b/scrapers/classes/parsersxe/tests/__snapshots__/termListParser.test.js.snap
@@ -3,18 +3,21 @@
 exports[`termListParser pulls out relevant data 1`] = `
 Array [
   Object {
+    "active": true,
     "host": "neu.edu",
     "subCollege": "CPS",
     "termId": "202034",
     "text": "Spring 2020 Semester",
   },
   Object {
+    "active": true,
     "host": "neu.edu",
     "subCollege": "LAW",
     "termId": "202032",
     "text": "Spring 2020 Semester",
   },
   Object {
+    "active": true,
     "host": "neu.edu",
     "subCollege": "NEU",
     "termId": "202030",

--- a/scrapers/classes/parsersxe/tests/bannerv9Parser.test.ts
+++ b/scrapers/classes/parsersxe/tests/bannerv9Parser.test.ts
@@ -47,18 +47,21 @@ describe("getAllTermInfos", () => {
   it("serializes the term list", async () => {
     expect(await bannerv9.getAllTermInfos("termslist")).toEqual([
       {
+        active: true,
         host: "neu.edu",
         subCollege: "NEU",
         termId: "3",
         text: "Fall 2022 Semester",
       },
       {
+        active: true,
         host: "neu.edu",
         subCollege: "LAW",
         termId: "2",
         text: "Summer 2022 Semester",
       },
       {
+        active: true,
         host: "neu.edu",
         subCollege: "CPS",
         termId: "1",
@@ -75,6 +78,7 @@ describe("main", () => {
     process.env.TERMS_TO_SCRAPE = "1";
     bannerv9.main([
       {
+        active: true,
         subCollege: "CPS",
         termId: "1",
         text: "Summer 2022 Semester",
@@ -127,16 +131,19 @@ it("getCurrentTermInfos", async () => {
   expect(
     await bannerv9.getCurrentTermInfos([
       {
+        active: true,
         subCollege: "NEU",
         termId: "3",
         text: "Fall 2022 Semester",
       },
       {
+        active: true,
         subCollege: "LAW",
         termId: "2",
         text: "Summer 2022 Semester",
       },
       {
+        active: true,
         subCollege: "CPS",
         termId: "1",
         text: "Summer 2022 Semester",
@@ -144,11 +151,13 @@ it("getCurrentTermInfos", async () => {
     ])
   ).toEqual([
     {
+      active: true,
       subCollege: "LAW",
       termId: "2",
       text: "Summer 2022 Semester",
     },
     {
+      active: true,
       subCollege: "CPS",
       termId: "1",
       text: "Summer 2022 Semester",

--- a/scrapers/main.ts
+++ b/scrapers/main.ts
@@ -21,8 +21,11 @@ class Main {
     const allTermInfos = await bannerv9parser.getAllTermInfos(
       bannerv9CollegeUrls[0]
     );
+    // Filter out any past semesters
+    const activeTermInfos = allTermInfos.filter((t) => t.active);
+
     const currentTermInfos = await bannerv9parser.getCurrentTermInfos(
-      allTermInfos
+      activeTermInfos
     );
 
     // Scraping should NOT be resolved simultaneously (eg. via p-map):

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -213,17 +213,19 @@ class DumpProcessor {
       });
 
       // Upsert new term IDs, along with their names and sub college
-      for (const { termId, subCollege, text } of termInfos) {
+      for (const { termId, subCollege, text, active } of termInfos) {
         await prisma.termInfo.upsert({
           where: { termId },
           update: {
             text,
             subCollege,
+            active,
           },
           create: {
             termId,
             text,
             subCollege,
+            active,
           },
         });
       }

--- a/types/types.ts
+++ b/types/types.ts
@@ -151,6 +151,7 @@ export interface TermInfo {
   termId: string;
   subCollege: string;
   text: string;
+  active: boolean;
 }
 
 export interface CourseRef {


### PR DESCRIPTION
# Purpose

Right now we scrape past semesters while we only care about current and future semesters. This pr adds an "active" field to each termInfo (schema representing a term).

# Tickets

_What Trello tickets (if any) are associated with this PR?_

- https://trello.com/c/CQ0p1Ms4/391-mark-past-terms-as-inactive

# Contributors
@pranavphadke1 


# Feature List

- added an "active" field to termInfo prisma schema

# Reviewers

**Primary**:
@hankewyczz @sebwittr 

**Secondary**:
@Lucas-Dunker 