### PR TITLE
Remove hacky Typescript conversions when working with Prisma

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,13 @@ module.exports = {
         ],
         "@typescript-eslint/explicit-module-boundary-types": "off",
         "@typescript-eslint/ban-ts-comment": "warn",
+        // We disable the base rule so it doesn't interfere w/ the TS one
+        "no-unused-vars": "off",
+        "@typescript-eslint/no-unused-vars": [
+          "warn",
+          // Ignore this rule for variables starting with an underscore (eg. _ignoreme)
+          { varsIgnorePattern: "^_" },
+        ],
       },
     },
   ],

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -16,7 +16,10 @@ import {
   Section,
   convertSectionToPrismaType,
 } from "../types/types";
-import { ParsedCourseSR } from "../types/scraperTypes";
+import {
+  ParsedCourseSR,
+  convertCourseToPrismaType,
+} from "../types/scraperTypes";
 
 class DumpProcessor {
   /**
@@ -34,7 +37,7 @@ class DumpProcessor {
     await this.saveEmployeesToDatabase(profDump);
 
     const processedCourses = termDump.classes.map((c) =>
-      convertCourseToDatabaseFormat(c)
+      convertCourseToPrismaType(c)
     );
     await this.saveCoursesToDatabase(processedCourses);
 
@@ -315,6 +318,3 @@ if (require.main === module) {
 }
 
 export default instance;
-function convertCourseToDatabaseFormat(c: ParsedCourseSR): any {
-  throw new Error("Function not implemented.");
-}

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -333,10 +333,10 @@ class DumpProcessor {
       prereqs: this.convertRequisiteToNullableDatabaseFormat(classInfo.prereqs),
       coreqs: this.convertRequisiteToNullableDatabaseFormat(classInfo.coreqs),
       optPrereqsFor: this.convertRequisitesToNullableDatabaseFormat(
-        classInfo.optPrereqsFor.values
+        classInfo.optPrereqsFor?.values ?? []
       ),
       prereqsFor: this.convertRequisitesToNullableDatabaseFormat(
-        classInfo.prereqsFor.values
+        classInfo.prereqsFor?.values ?? []
       ),
       lastUpdateTime: new Date(classInfo.lastUpdateTime),
     };

--- a/services/dumpProcessor.ts
+++ b/services/dumpProcessor.ts
@@ -321,8 +321,11 @@ class DumpProcessor {
   convertCourseToDatabaseFormat(
     classInfo: ParsedCourseSR
   ): Prisma.CourseCreateInput {
+    // Strip out the keys that Prisma doesn't recognize
+    const { desc: _desc, college: _college, ...cleanClassInfo } = classInfo;
+
     return {
-      ...classInfo,
+      ...cleanClassInfo,
       id: keys.getClassHash(classInfo),
       description: classInfo.desc,
       minCredits: Math.floor(classInfo.minCredits),
@@ -394,8 +397,17 @@ class DumpProcessor {
   convertSectionToDatabaseFormat(
     secInfo: Section
   ): Prisma.SectionUncheckedCreateInput {
+    // Strip out the keys that Prisma doesn't recognize
+    const {
+      classId: _classId,
+      termId: _termId,
+      subject: _subject,
+      host: _host,
+      ...cleanSecInfo
+    } = secInfo;
+
     return {
-      ...secInfo,
+      ...cleanSecInfo,
       id: `${keys.getSectionHash(secInfo)}`,
       classHash: keys.getClassHash(secInfo),
       meetings: this.convertBackendMeetingsToDatabaseFormat(secInfo.meetings),

--- a/tests/database/dumpProcessor.test.seq.ts
+++ b/tests/database/dumpProcessor.test.seq.ts
@@ -255,7 +255,7 @@ describe("with sections", () => {
           campus: "Boston",
           honors: false,
           crn: "12345",
-          meetings: {},
+          meetings: [],
         },
         {
           host: "neu.edu",
@@ -267,7 +267,7 @@ describe("with sections", () => {
           campus: "Online",
           honors: false,
           crn: "23456",
-          meetings: {},
+          meetings: [],
         },
         {
           host: "neu.edu",
@@ -279,7 +279,7 @@ describe("with sections", () => {
           campus: "Seattle, WA",
           honors: false,
           crn: "34567",
-          meetings: {},
+          meetings: [],
         },
       ],
       subjects: [],
@@ -330,7 +330,7 @@ describe("with updates", () => {
         campus: "Boston",
         honors: false,
         crn: "34567",
-        meetings: {},
+        meetings: [],
       },
     });
 

--- a/types/types.ts
+++ b/types/types.ts
@@ -3,10 +3,53 @@
  * See the license file in the root folder for details.
  */
 
-// A block of meetings, ex: "Tuesdays+Fridays, 9:50-11:30am"
 import { ParsedTermSR } from "./scraperTypes";
 import { Prisma } from "@prisma/client";
+import keys from "../utils/keys";
 
+/**
+ * Converts a {@link MeetingTime} to a format compatible with Prisma.
+ *
+ * This doesn't do much at the moment, but it's useful for future-proofing.
+ */
+function convertMeetingTimeToPrismaType(
+  meeting: MeetingTime
+): Prisma.InputJsonObject {
+  return { ...meeting };
+}
+
+/**
+ * Converts a single {@link BackendMeeting} to a format compatible with Prisma.
+ */
+export function convertBackendMeetingToPrismaType(
+  meeting: BackendMeeting
+): Prisma.InputJsonObject {
+  // Essentially, this takes a object with keys and values, and replaces every value with fn(value).
+  // That `fn`, in this case, is the `convertMeetingTimeToDatabaseFormat` function.
+  const times: Prisma.InputJsonObject = Object.fromEntries(
+    // `entries` takes an object and converts it to an array of [key, value] pairs.
+    // `fromEntries` does the opposite
+    // So, we convert to entries, transform the values, then convert back to an object
+    Object.entries(meeting.times).map(([key, val]) => {
+      return [key, val.map((v) => convertMeetingTimeToPrismaType(v))];
+    })
+  );
+  return { ...meeting, times };
+}
+
+/**
+ * Converts a {@link BackendMeeting} array to a format compatible with Prisma.
+ */
+export function convertBackendMeetingsToPrismaType(
+  meetings?: BackendMeeting[]
+): Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue {
+  if (meetings === undefined) {
+    return Prisma.DbNull;
+  }
+
+  return meetings.map((val) => convertBackendMeetingToPrismaType(val));
+}
+// A block of meetings, ex: "Tuesdays+Fridays, 9:50-11:30am"
 export interface BackendMeeting {
   startDate: number;
   endDate: number;
@@ -105,6 +148,40 @@ export interface Course {
   sections?: Section[];
 }
 
+/**
+ * Converts an optional {@link Requisite} to a format compatible with Prisma.
+ */
+export function convertRequisiteToNullablePrismaType(
+  req: Requisite | undefined
+): Prisma.NullableJsonNullValueInput | Prisma.InputJsonValue {
+  if (req === undefined) {
+    return Prisma.DbNull;
+  }
+
+  return convertRequisiteToPrismaType(req);
+}
+
+/**
+ * Converts a {@link Requisite} to a format compatible with Prisma.
+ *
+ * Currently, this function does little. It's essentially a way to tell Typescript, "yeah, they're the same types".
+ * However, this is useful because it allows us to easily change the format of the requisite in the future.
+ */
+export function convertRequisiteToPrismaType(
+  req: Requisite
+): Prisma.InputJsonValue {
+  if (typeof req === "string") {
+    return req;
+  } else if ("classId" in req) {
+    return req;
+  } else {
+    return {
+      ...req,
+      values: req.values.map((val) => convertRequisiteToPrismaType(val)),
+    };
+  }
+}
+
 // A co or pre requisite object.
 export type Requisite = string | BooleanReq | CourseReq;
 
@@ -125,6 +202,42 @@ export function isBooleanReq(req: Requisite): req is BooleanReq {
 
 export function isCourseReq(req: Requisite): req is CourseReq {
   return (req as CourseReq).classId !== undefined;
+}
+
+/**
+ * Converts one of our section types to a type compatible with the format required by Prisma.
+ * The converted section is ready for insertion to our database.
+ */
+export function convertSectionToPrismaType(
+  secInfo: Section
+): Prisma.SectionCreateInput {
+  // Strip out the keys that Prisma doesn't recognize
+  const {
+    classId: _classId,
+    termId: _termId,
+    subject: _subject,
+    host: _host,
+    ...cleanSecInfo
+  } = secInfo;
+
+  return {
+    ...cleanSecInfo,
+    id: `${keys.getSectionHash(secInfo)}`,
+    meetings: convertBackendMeetingsToPrismaType(secInfo.meetings),
+    lastUpdateTime: new Date(secInfo.lastUpdateTime),
+    course: {
+      // This links our section with the course matching the given info.
+      // This requires that the course already exists! We check this earlier on.
+      // If not, this will error.
+      connect: {
+        uniqueCourseProps: {
+          classId: secInfo.classId,
+          termId: secInfo.termId,
+          subject: secInfo.subject,
+        },
+      },
+    } as Prisma.CourseCreateNestedOneWithoutSectionsInput,
+  };
 }
 
 // A section of a course

--- a/types/types.ts
+++ b/types/types.ts
@@ -108,16 +108,16 @@ export interface Course {
 // A co or pre requisite object.
 export type Requisite = string | BooleanReq | CourseReq;
 
-export interface BooleanReq {
+export type BooleanReq = {
   type: "and" | "or";
   values: Requisite[];
-}
+};
 
-export interface CourseReq {
+export type CourseReq = {
   classId: string;
   subject: string;
   missing?: true;
-}
+};
 
 export function isBooleanReq(req: Requisite): req is BooleanReq {
   return (req as BooleanReq).type !== undefined;


### PR DESCRIPTION
# Purpose

_In 2-3 sentences - what does this code actually do, and why?_

When working with Prisma, a common pattern we had littered around was `variable as unknown as Prisma.<type>`. 

Essentially, Typescript wouldn't let us cast to `Prisma.<type>`, so casting to `unknown` first allowed us to _force_ the conversion.

Needless to say, that's a bad idea. This removes that behavior by adding explicit conversion functions

# Tickets

_What Trello tickets (if any) are associated with this PR?_

- N/A

# Reviewers

Secondary reviewers: @soulwa 
