### PR TITLE
Move code determining which terms to scrape up out of the Banner parser

### DIFF
--- a/scrapers/classes/main.ts
+++ b/scrapers/classes/main.ts
@@ -14,7 +14,6 @@ import addPrerequisiteFor from "./processors/addPrerequisiteFor";
 // Parsers
 import { instance as bannerv9Parser } from "./parsersxe/bannerv9Parser";
 import { ParsedTermSR } from "../../types/scraperTypes";
-import { TermInfo } from "../../types/types";
 
 // This is the main entry point for scraping classes
 // This file calls into the first Banner v8 parser, the processors, and hopefully soon, the v9 parsers too.
@@ -38,7 +37,7 @@ class Main {
   /**
    * The main entrypoint for scraping courses.
    */
-  async main(termInfos: TermInfo[]): Promise<ParsedTermSR> {
+  async main(termIds: string[]): Promise<ParsedTermSR> {
     if (macros.DEV && !process.env.CUSTOM_SCRAPE) {
       const cached = await cache.get(
         macros.DEV_DATA_DIR,
@@ -53,7 +52,7 @@ class Main {
     }
 
     macros.log("Scraping classes...".blue.underline);
-    const bannerv9ParserOutput = await bannerv9Parser.main(termInfos);
+    const bannerv9ParserOutput = await bannerv9Parser.main(termIds);
     macros.log("Done scraping classes\n\n".green.underline);
 
     const dump = this.runProcessors(bannerv9ParserOutput);

--- a/scrapers/classes/parsersxe/tests/bannerv9Parser.test.ts
+++ b/scrapers/classes/parsersxe/tests/bannerv9Parser.test.ts
@@ -1,7 +1,4 @@
-import {
-  instance as bannerv9,
-  NUMBER_OF_TERMS_TO_UPDATE,
-} from "../bannerv9Parser";
+import { instance as bannerv9 } from "../bannerv9Parser";
 import filters from "../../../filters";
 import prisma from "../../../../services/prisma";
 import TermParser from "../termParser";
@@ -29,41 +26,6 @@ const scope = nock(/neu\.edu/)
 
 afterAll(() => {
   scope.persist(false);
-});
-
-describe("getTermsIds", () => {
-  beforeEach(() => {
-    process.env.TERMS_TO_SCRAPE = "";
-  });
-
-  it("returns the termsStr if and only if they're in the terms list", () => {
-    process.env.TERMS_TO_SCRAPE = "202210,202230,202250";
-    expect(bannerv9.getTermsIds([])).toEqual([]);
-    expect(bannerv9.getTermsIds(["202210"])).toEqual(["202210"]);
-    expect(
-      bannerv9.getTermsIds(["202210", "202230", "202250", "1234"])
-    ).toEqual(["202210", "202230", "202250"]);
-  });
-
-  it("without a termStr, it takes NUMBER_OF_TERMS_TO_PARSE terms", () => {
-    process.env.NUMBER_OF_TERMS = "0";
-    const termIds = new Array(10).fill("a");
-    expect(bannerv9.getTermsIds(termIds).length).toBe(0);
-
-    process.env.NUMBER_OF_TERMS = "5";
-    expect(bannerv9.getTermsIds(termIds).length).toBe(5);
-
-    process.env.NUMBER_OF_TERMS = "20";
-    expect(bannerv9.getTermsIds(termIds).length).toBe(10);
-  });
-
-  it("defaults to NUMEBR_OF_TERMS_TO_SCRAPE", () => {
-    delete process.env.NUMBER_OF_TERMS;
-    const termIds = new Array(30).fill("a");
-    expect(bannerv9.getTermsIds(termIds).length).toBe(
-      NUMBER_OF_TERMS_TO_UPDATE
-    );
-  });
 });
 
 describe("getAllTermInfos", () => {
@@ -96,13 +58,7 @@ describe("main", () => {
     const originalScrape = bannerv9.scrapeTerms;
     bannerv9.scrapeTerms = jest.fn();
     process.env.TERMS_TO_SCRAPE = "1";
-    bannerv9.main([
-      {
-        subCollege: "CPS",
-        termId: "1",
-        text: "Summer 2022 Semester",
-      },
-    ]);
+    bannerv9.main(["1"]);
     expect(bannerv9.scrapeTerms).toHaveBeenLastCalledWith(["1"]);
 
     delete process.env.TERMS_TO_SCRAPE;

--- a/scrapers/classes/tests/classScraper.test.ts
+++ b/scrapers/classes/tests/classScraper.test.ts
@@ -1,0 +1,36 @@
+import scraper, { NUMBER_OF_TERMS_TO_UPDATE } from "../../main";
+
+describe("getTermsIds", () => {
+  beforeEach(() => {
+    process.env.TERMS_TO_SCRAPE = "";
+  });
+
+  it("returns the termsStr if and only if they're in the terms list", () => {
+    process.env.TERMS_TO_SCRAPE = "202210,202230,202250";
+    expect(scraper.getTermIdsToScrape([])).toEqual([]);
+    expect(scraper.getTermIdsToScrape(["202210"])).toEqual(["202210"]);
+    expect(
+      scraper.getTermIdsToScrape(["202210", "202230", "202250", "1234"])
+    ).toEqual(["202210", "202230", "202250"]);
+  });
+
+  it("without a termStr, it takes NUMBER_OF_TERMS_TO_PARSE terms", () => {
+    process.env.NUMBER_OF_TERMS = "0";
+    const termIds = new Array(10).fill("a");
+    expect(scraper.getTermIdsToScrape(termIds).length).toBe(0);
+
+    process.env.NUMBER_OF_TERMS = "5";
+    expect(scraper.getTermIdsToScrape(termIds).length).toBe(5);
+
+    process.env.NUMBER_OF_TERMS = "20";
+    expect(scraper.getTermIdsToScrape(termIds).length).toBe(10);
+  });
+
+  it("defaults to NUMEBR_OF_TERMS_TO_SCRAPE", () => {
+    delete process.env.NUMBER_OF_TERMS;
+    const termIds = new Array(30).fill("a");
+    expect(scraper.getTermIdsToScrape(termIds).length).toBe(
+      NUMBER_OF_TERMS_TO_UPDATE
+    );
+  });
+});

--- a/scrapers/main.ts
+++ b/scrapers/main.ts
@@ -14,18 +14,56 @@ import "colors";
 // Main file for scraping
 // Run this to run all the scrapers
 
+/*
+At most, there are 12 terms that we want to update - if we're in the spring & summer semesters have been posted
+- Undergrad: Spring, summer (Full, I, and II)
+- CPS: spring (semester & quarter), summer (semester & quarter)
+- Law: spring (semester & quarter), summer (semester & quarter)
+
+However, we allow for overriding this number via the `NUMBER_OF_TERMS` env variable
+*/
+export const NUMBER_OF_TERMS_TO_UPDATE = 12;
+
 class Main {
+  getTermIdsToScrape(termIds: string[]): string[] {
+    const termsStr = process.env.TERMS_TO_SCRAPE;
+
+    if (termsStr) {
+      const terms = termsStr.split(",").filter((termId) => {
+        if (!termIds.includes(termId) && termId !== null) {
+          macros.warn(
+            `${termId} not in list of term IDs from Banner! Skipping`
+          );
+        }
+        return termIds.includes(termId);
+      });
+
+      macros.log("Scraping using user-provided TERMS_TO_SCRAPE");
+      return terms;
+    }
+
+    const rawNumTerms = Number.parseInt(process.env.NUMBER_OF_TERMS);
+    const numTerms = isNaN(rawNumTerms)
+      ? NUMBER_OF_TERMS_TO_UPDATE
+      : rawNumTerms;
+
+    return termIds.slice(0, numTerms);
+  }
+
   async main(): Promise<void> {
     const start = Date.now();
     // Get the TermInfo information from Banner
     const allTermInfos = await bannerv9parser.getAllTermInfos();
+    const termsToScrape = this.getTermIdsToScrape(
+      allTermInfos.map((t) => t.termId)
+    );
 
     // Scraping should NOT be resolved simultaneously (eg. via p-map):
     //  *Employee scraping takes SO MUCH less time (which is why we run it first)
     //    * So, not running scraping in parallel doesn't hurt us
     //  * It would make logging a mess (are the logs from employee scraping, or from class scraping?)
     const mergedEmployees = await matchEmployees.main();
-    const termDump = await classes.main(allTermInfos);
+    const termDump = await classes.main(termsToScrape);
 
     await dumpProcessor.main({
       termDump: termDump,
@@ -45,6 +83,7 @@ class Main {
 }
 
 const instance = new Main();
+export default instance;
 
 if (require.main === module) {
   instance

--- a/services/updater.ts
+++ b/services/updater.ts
@@ -14,8 +14,7 @@ import termParser from "../scrapers/classes/parsersxe/termParser";
 import { Section as ScrapedSection } from "../types/types";
 import { sendNotifications } from "./notifyer";
 import { NotificationInfo } from "../types/notifTypes";
-
-import { NUMBER_OF_TERMS_TO_UPDATE } from "../scrapers/classes/parsersxe/bannerv9Parser";
+import { NUMBER_OF_TERMS_TO_UPDATE } from "../scrapers/main";
 
 const FAULTY_TERM_IDS = ["202225"];
 


### PR DESCRIPTION
# Purpose

_In 2-3 sentences - what does this code actually do, and why?_

Our Banner parser has some code that shouldn't logically be there. This PR just shuffles code around to make the organization more intuitive. 

The Banner parser _used to_ be responsible for determining what terms should be scraped. That's irrelevant to parsing, and this functionality should belong to the scraper itself. 

# Reviewers

Primary reviewer:

- Pick one primary reviewer
  - The team member with the most relevant knowledge about the code area this PR touches
  - **NOT** an author of the PR
  - If the primary reviewer is the project lead, _select two primary reviewers_
    - Goal: facilitate knowledge transfer to other team members
  - Primary reviewers **are required to approve the PR** before it can be merged

**Primary**:

Use the **"Reviewers"** feature in Github

Secondary reviewers:

- Pick as many as appropriate — anyone who would benefit from reading the PR
  - Tag them using their Github usernames below

**Secondary**:
