### PR TITLE
By default, the scraper should only scrape new terms

### DIFF
--- a/infrastructure/terraform/modules/course-catalog-api/rds.tf
+++ b/infrastructure/terraform/modules/course-catalog-api/rds.tf
@@ -5,7 +5,7 @@ resource "aws_db_instance" "default" {
   engine                 = "postgres"
   engine_version         = "11.17"
   instance_class         = "db.t3.small"
-  name                   = replace(module.label.name, module.label.delimiter, "")
+  db_name                = replace(module.label.name, module.label.delimiter, "")
   username               = "postgres"
   password               = random_password.db_pass.result
   parameter_group_name   = "default.postgres11"

--- a/scrapers/main.ts
+++ b/scrapers/main.ts
@@ -14,25 +14,22 @@ import "colors";
 // Main file for scraping
 // Run this to run all the scrapers
 
-/*
-At most, there are 12 terms that we want to update - if we're in the spring & summer semesters have been posted
-- Undergrad: Spring, summer (Full, I, and II)
-- CPS: spring (semester & quarter), summer (semester & quarter)
-- Law: spring (semester & quarter), summer (semester & quarter)
-
-However, we allow for overriding this number via the `NUMBER_OF_TERMS` env variable
-*/
-export const NUMBER_OF_TERMS_TO_UPDATE = 12;
-
 class Main {
-  getTermIdsToScrape(termIds: string[]): string[] {
-    const termsStr = process.env.TERMS_TO_SCRAPE;
+  /**
+   * Given a list of term IDs, return a subset which will be used to run the scrapers.
+   * The returned term IDs can be determined by environment variables or by their existance in our database
+   */
+  async getTermIdsToScrape(termIds: string[]): Promise<string[]> {
+    const termsToScrapeStr = process.env.TERMS_TO_SCRAPE;
+    const numOfTermsStr = Number.parseInt(process.env.NUMBER_OF_TERMS);
 
-    if (termsStr) {
-      const terms = termsStr.split(",").filter((termId) => {
+    if (termsToScrapeStr) {
+      const unfilteredTermIds = termsToScrapeStr.split(",");
+
+      const terms = unfilteredTermIds.filter((termId) => {
         if (!termIds.includes(termId) && termId !== null) {
           macros.warn(
-            `${termId} not in list of term IDs from Banner! Skipping`
+            `"${termId}" not in list of term IDs from Banner! Skipping`
           );
         }
         return termIds.includes(termId);
@@ -40,21 +37,23 @@ class Main {
 
       macros.log("Scraping using user-provided TERMS_TO_SCRAPE");
       return terms;
+    } else if (!isNaN(numOfTermsStr)) {
+      return termIds.slice(0, numOfTermsStr);
+    } else {
+      const termInfosWithData = await prisma.termInfo.findMany({
+        select: { termId: true },
+      });
+      const termIdsWithData = new Set(termInfosWithData.map((t) => t.termId));
+
+      return termIds.filter((t) => !termIdsWithData.has(t));
     }
-
-    const rawNumTerms = Number.parseInt(process.env.NUMBER_OF_TERMS);
-    const numTerms = isNaN(rawNumTerms)
-      ? NUMBER_OF_TERMS_TO_UPDATE
-      : rawNumTerms;
-
-    return termIds.slice(0, numTerms);
   }
 
   async main(): Promise<void> {
     const start = Date.now();
     // Get the TermInfo information from Banner
     const allTermInfos = await bannerv9parser.getAllTermInfos();
-    const termsToScrape = this.getTermIdsToScrape(
+    const termsToScrape = await this.getTermIdsToScrape(
       allTermInfos.map((t) => t.termId)
     );
 

--- a/scrapers/main.ts
+++ b/scrapers/main.ts
@@ -27,12 +27,11 @@ class Main {
       const unfilteredTermIds = termsToScrapeStr.split(",");
 
       const terms = unfilteredTermIds.filter((termId) => {
-        if (!termIds.includes(termId) && termId !== null) {
-          macros.warn(
-            `"${termId}" not in list of term IDs from Banner! Skipping`
-          );
+        const keep = termIds.includes(termId);
+        if (!keep && termId !== null) {
+          macros.warn(`"${termId}" not in given list - skipping`);
         }
-        return termIds.includes(termId);
+        return keep;
       });
 
       macros.log("Scraping using user-provided TERMS_TO_SCRAPE");

--- a/services/updater.ts
+++ b/services/updater.ts
@@ -14,7 +14,17 @@ import termParser from "../scrapers/classes/parsersxe/termParser";
 import { Section as ScrapedSection } from "../types/types";
 import { sendNotifications } from "./notifyer";
 import { NotificationInfo } from "../types/notifTypes";
-import { NUMBER_OF_TERMS_TO_UPDATE } from "../scrapers/main";
+
+/*
+At most, there are 12 terms that we want to update - if we're in the spring & summer semesters have been posted
+- Undergrad: Spring, summer (Full, I, and II)
+- CPS: spring (semester & quarter), summer (semester & quarter)
+- Law: spring (semester & quarter), summer (semester & quarter)
+
+TODO - once #178 is merged, we should switch to that! Only update the active terms.
+
+*/
+export const NUMBER_OF_TERMS_TO_UPDATE = 12;
 
 const FAULTY_TERM_IDS = ["202225"];
 

--- a/tests/end_to_end/elastic.test.git.ts
+++ b/tests/end_to_end/elastic.test.git.ts
@@ -41,8 +41,8 @@ it("Creating indexes", async () => {
 it("queries", async () => {
   const aliasName = "e2e-employees-jason";
 
+  // @ts-expect-error - type doesn't match, that's OK
   client["indexes"][aliasName] = {
-    name: `${aliasName}_blue`,
     mapping: employeeMap,
   };
 


### PR DESCRIPTION
# Purpose

_In 2-3 sentences - what does this code actually do, and why?_

Our scrapers used to be divided:
- Scraping scrapes class data
- Updating scrapes section data

Now, with #190, that line has been blurred. Once a term is scraped initially, the updater will automatically scrape any new classes _for that term_.

Therefore, there's no need to scrape a term more than once anymore (unless the class titles, descriptions, etc. change).

So, we should default our scrapers to only scrape __NEW__ terms. Of course, this can be overridden by several env. variables.

# Reviewers

Primary reviewer:

- Pick one primary reviewer
  - The team member with the most relevant knowledge about the code area this PR touches
  - **NOT** an author of the PR
  - If the primary reviewer is the project lead, _select two primary reviewers_
    - Goal: facilitate knowledge transfer to other team members
  - Primary reviewers **are required to approve the PR** before it can be merged

**Primary**:

Use the **"Reviewers"** feature in Github

Secondary reviewers:

- Pick as many as appropriate — anyone who would benefit from reading the PR
  - Tag them using their Github usernames below

**Secondary**:
