### PR TITLE
Tweak default scraping behavior

### DIFF
--- a/scrapers/classes/tests/classScraper.test.ts
+++ b/scrapers/classes/tests/classScraper.test.ts
@@ -41,13 +41,13 @@ describe("getTermsIds", () => {
       expect((await scraper.getTermIdsToScrape(termIds)).length).toBe(4);
     });
 
-    it("returns those which do not already exist in the DB", async () => {
+    it("returns those newer than those that already exist in the DB", async () => {
       const termsToReturn = [{ termId: "123" }, { termId: "456" }];
       // @ts-expect-error - the type isn't a PrismaPromise so TS will complain
       jest.spyOn(prisma.termInfo, "findMany").mockReturnValue(termsToReturn);
 
       const returnedTerms = await scraper.getTermIdsToScrape(termIds);
-      expect(returnedTerms.sort()).toEqual(termIds.slice(2).sort());
+      expect(returnedTerms).toEqual(["789"]);
     });
 
     it("returns an empty list if all terms already exist", async () => {

--- a/scrapers/main.ts
+++ b/scrapers/main.ts
@@ -45,7 +45,9 @@ class Main {
       const termIdsWithData = termInfosWithData.map((t) => t.termId).sort();
       const newestTermIdWithData = termIdsWithData[termIdsWithData.length - 1];
 
-      return termIds.filter((t) => t > newestTermIdWithData);
+      return termIds.filter(
+        (t) => newestTermIdWithData === undefined || t > newestTermIdWithData
+      );
     }
   }
 

--- a/scrapers/main.ts
+++ b/scrapers/main.ts
@@ -42,9 +42,10 @@ class Main {
       const termInfosWithData = await prisma.termInfo.findMany({
         select: { termId: true },
       });
-      const termIdsWithData = new Set(termInfosWithData.map((t) => t.termId));
+      const termIdsWithData = termInfosWithData.map((t) => t.termId).sort();
+      const newestTermIdWithData = termIdsWithData[termIdsWithData.length - 1];
 
-      return termIds.filter((t) => !termIdsWithData.has(t));
+      return termIds.filter((t) => t > newestTermIdWithData);
     }
   }
 


### PR DESCRIPTION
# Purpose

_In 2-3 sentences - what does this code actually do, and why?_

The scraping changes made it so the default for the scraper only counted terms with no data, but neglected to omit old terms. There are terms for which we don't have data AND we don't care (eg. things over 3-4 years old). 