### PR TITLE
Update Postgres Version

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.19
+        image: postgres:11.5
         env:
           POSTGRES_MULTIPLE_DATABASES: searchneu_dev
           POSTGRES_USER: postgres

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11.5
+        image: postgres:11.19
         env:
           POSTGRES_MULTIPLE_DATABASES: searchneu_dev
           POSTGRES_USER: postgres

--- a/infrastructure/dev/docker-compose-server.yml
+++ b/infrastructure/dev/docker-compose-server.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   postgresql:
-    image: postgres:11.17-bullseye
+    image: postgres:11.19-bullseye
     ports:
       - 5432:5432
     volumes:

--- a/infrastructure/dev/docker-compose.yml
+++ b/infrastructure/dev/docker-compose.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   postgresql:
-    image: postgres:11.17-bullseye
+    image: postgres:11.19-bullseye
     ports:
       - 5432:5432
     volumes:

--- a/infrastructure/terraform/modules/course-catalog-api/rds.tf
+++ b/infrastructure/terraform/modules/course-catalog-api/rds.tf
@@ -3,7 +3,7 @@ resource "aws_db_instance" "default" {
   identifier             = module.label.id
   allocated_storage      = 20
   engine                 = "postgres"
-  engine_version         = "11.17"
+  engine_version         = "11.19"
   instance_class         = "db.t3.small"
   db_name                = replace(module.label.name, module.label.delimiter, "")
   username               = "postgres"

--- a/scrapers/employees/employees.ts
+++ b/scrapers/employees/employees.ts
@@ -99,7 +99,7 @@ class NeuEmployee {
     const employeeQuery = {
       versionInfo: {
         moduleVersion,
-        apiVersion: "ad_141F5PYcK3c+D5K8O+g",
+        apiVersion: "Zox0cGCdj_7M+WZErCpkhQ",
       },
       viewName: "MainFlow.FacultyAndStaffDirectory",
       // Their frontend requires non-null queries, but the backend doesn't :)


### PR DESCRIPTION
# Purpose

In preparation for migrating our AWS stuff, I noticed that there was a mismatch between our local and hosted posgres versions; our local postgres is `11.17`, but our hosted version is `11.19`! This PR updates everything to be universally `11.19`.


# Contributors
@Lucas-Dunker 

# Feature List

_Update our postgres version to 11.19

# Notes (Optional)

_Is there anything reviewers should note? Do we need to add something later? Any followups? Was this ticket easier/harder than predicted?_

# Reviewers

**Primary**:
@sebwit20 

**Secondary**:
@pranavphadke1  @allychao 