### PR TITLE
Update scraped course data with new CRN link

### DIFF
--- a/scrapers/classes/parsersxe/classParser.ts
+++ b/scrapers/classes/parsersxe/classParser.ts
@@ -107,12 +107,12 @@ class ClassParser {
       nupath: this.nupath(attributes),
       desc: he.decode(description),
       prettyUrl:
-        "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_course_detail?" +
+        "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?" +
         `cat_term_in=${termId}&subj_code_in=${subjectCode}&crse_numb_in=${courseNumber}`,
       name: he.decode(SR.courseTitle),
       url:
-        "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_listcrse?" +
-        `term_in=${termId}&subj_in=${subjectCode}&crse_in=${courseNumber}&schd_in=%`,
+        "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?" +
+        `cat_term_in=${termId}&subj_code_in=${subjectCode}&crse_numb_in=${courseNumber}`,
       lastUpdateTime: Date.now(),
       maxCredits: SR.creditHourHigh || SR.creditHourLow,
       minCredits: SR.creditHourLow,
@@ -120,7 +120,6 @@ class ClassParser {
       feeAmount,
       feeDescription,
     };
-
     if (prereqs) {
       classDetails.prereqs = prereqs;
     }

--- a/scrapers/classes/parsersxe/sectionParser.ts
+++ b/scrapers/classes/parsersxe/sectionParser.ts
@@ -63,8 +63,8 @@ class SectionParser {
         return a.description === "Honors";
       }),
       url:
-        "https://wl11gp.neu.edu/udcprod8/bwckschd.p_disp_detail_sched" +
-        `?term_in=${SR.term}&crn_in=${SR.courseReferenceNumber}`,
+        "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?" +
+        `cat_term_in=${SR.term}&subj_code_in=${SR.subject}&crse_numb_in=${SR.courseNumber}`,
       profs: SR.faculty.map(MeetingParser.profName),
       meetings: MeetingParser.parseMeetings(SR.meetingsFaculty),
     };

--- a/scrapers/classes/parsersxe/tests/__snapshots__/classParser.test.js.snap
+++ b/scrapers/classes/parsersxe/tests/__snapshots__/classParser.test.js.snap
@@ -35,10 +35,10 @@ Object {
       },
     ],
   },
-  "prettyUrl": "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CHEM&crse_numb_in=2311",
+  "prettyUrl": "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CHEM&crse_numb_in=2311",
   "subject": "CHEM",
   "termId": "202010",
-  "url": "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_listcrse?term_in=202010&subj_in=CHEM&crse_in=2311&schd_in=%",
+  "url": "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CHEM&crse_numb_in=2311",
 }
 `;
 
@@ -77,9 +77,9 @@ Object {
       },
     ],
   },
-  "prettyUrl": "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CS&crse_numb_in=2500",
+  "prettyUrl": "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CS&crse_numb_in=2500",
   "subject": "CS",
   "termId": "202010",
-  "url": "https://wl11gp.neu.edu/udcprod8/bwckctlg.p_disp_listcrse?term_in=202010&subj_in=CS&crse_in=2500&schd_in=%",
+  "url": "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CS&crse_numb_in=2500",
 }
 `;

--- a/scrapers/classes/parsersxe/tests/__snapshots__/sectionParser.test.js.snap
+++ b/scrapers/classes/parsersxe/tests/__snapshots__/sectionParser.test.js.snap
@@ -51,7 +51,7 @@ Object {
   "seatsRemaining": 36,
   "subject": "CHEM",
   "termId": "202010",
-  "url": "https://wl11gp.neu.edu/udcprod8/bwckschd.p_disp_detail_sched?term_in=202010&crn_in=10259",
+  "url": "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?cat_term_in=202010&subj_code_in=CHEM&crse_numb_in=2311",
   "waitCapacity": 0,
   "waitRemaining": 0,
 }
@@ -101,7 +101,7 @@ Object {
   "seatsRemaining": 4,
   "subject": "CS",
   "termId": "201930",
-  "url": "https://wl11gp.neu.edu/udcprod8/bwckschd.p_disp_detail_sched?term_in=201930&crn_in=30340",
+  "url": "https://bnrordsp.neu.edu/ssb-prod/bwckctlg.p_disp_course_detail?cat_term_in=201930&subj_code_in=CS&crse_numb_in=2500",
   "waitCapacity": 0,
   "waitRemaining": 0,
 }

--- a/scrapers/request.ts
+++ b/scrapers/request.ts
@@ -75,7 +75,7 @@ const separateReqPools: Record<string, RequestPool> = {
   // Took 1hr and 15 min with 500 sockets and RETRY_DELAY set to 20000 and delta set to 15000.
   // Usually takes just under 1 hr at 1k sockets and the same timeouts.
   // Took around 20 min with timeouts set to 100ms and 150ms and 100 sockets.
-  "wl11gp.neu.edu": {
+  "https://bnrordsp.neu.edu": {
     options: { maxSockets: 100, keepAlive: true, maxFreeSockets: 100 },
     agents: false,
   },


### PR DESCRIPTION
# Purpose

Northeastern changed their provider for CRN data in their courses, meaning that all of our URL's no longer work. This ticket changes our scraper to get URL's from their new provider. 

# Tickets

[Ticket](https://trello.com/c/ih7pTGzg/409-crns-dont-work-anymore)

# Contributors

@Lucas-Dunker 

# Feature List

* Replace the old, now-defunct CRN link to the new, functional one. 


# Reviewers

**Primary**:
@sebwittr @pranavphadke1 

**Secondary**:
@ananyaspatil 
