### PR TITLE
Delete notifications through text

### DIFF
--- a/twilio/notifs.ts
+++ b/twilio/notifs.ts
@@ -162,6 +162,16 @@ class TwilioNotifyer {
     switch (message) {
       // TODO: actually remove user from SearchNEU notifs
       case this.TWILIO_REPLIES.STOP_ALL:
+        try {
+          notificationsManager.deleteAllUserSubscriptions(senderNumber);
+        } catch (e) {
+          macros.log(
+            "Error deleting notifications from: " +
+              senderNumber +
+              " Error Message: " +
+              e
+          );
+        }
         twimlResponse.message(
           "You have been removed from all SearchNEU notifications."
         );


### PR DESCRIPTION
# Purpose

This PR allows all notifications to be deleted through text message by replying "STOP ALL". To delete specific notifications we'll have people use the subscription page.

# Tickets

_What Trello tickets (if any) are associated with this PR?_

- https://trello.com/c/EgxVy3JZ/343-allow-the-user-to-text-stop-all-to-delete-all-their-subscriptions 

# Contributors

@sebwittr 

# Feature List

The code for deleting all notifications already existed, but for some reason it was not being called when we handled twilio responses. This just calls that function and lets the user know if went through or errors happened.



# Reviewers

Primary reviewer: @Lucas-Dunker 

Secondary reviewers: @ananyaspatil @pranavphadke1 


