### PR TITLE
Have better section filtering

### DIFF
--- a/scrapers/classes/classMapping.json
+++ b/scrapers/classes/classMapping.json
@@ -41,7 +41,8 @@
         }
       },
       "sections": {
-        "type": "object",
+        "type": "nested",
+        "include_in_parent": "true",
         "properties": {
           "meetings": {
             "type": "object"

--- a/types/searchTypes.ts
+++ b/types/searchTypes.ts
@@ -12,6 +12,7 @@ type OneOrMany<T> = T | T[];
 export interface EsQuery {
   from: number;
   size: number;
+  min_score: number;
   sort: EsSort;
   query: QueryNode;
   aggregations?: QueryAgg;
@@ -35,7 +36,9 @@ export type LeafQuery =
   | MultiMatchQuery
   | RangeQuery
   | MatchAllQuery
-  | BoolQuery;
+  | BoolQuery
+  | NestedQuery<LeafQuery>
+  | SectionFilterQuery;
 
 export interface TermQuery {
   term: FieldQuery;
@@ -72,10 +75,16 @@ export interface ParsedQuery {
 export const MATCH_ALL_QUERY = { match_all: {} };
 export type MatchAllQuery = typeof MATCH_ALL_QUERY;
 
+export interface NestedQuery<T> {
+  nested: {
+    path: string;
+    query: T;
+  };
+}
+
 export interface ExistsQuery {
   exists: { field: string };
 }
-
 export interface FieldQuery {
   [fieldName: string]: EsValue;
 }


### PR DESCRIPTION
# Purpose

We have a bug where if you filter by "honors" and "campus", you won't guarantee that there will be one section with the given honors and campus. This will guarantee each class returned has one section matching both filters, and it filters out the rest of the sections as well. 

# Tickets

https://trello.com/c/v6dY3aCt/416-section-filters-should-only-return-classes-that-have-sections-that-match-both-filters



# Contributors

@ananyaspatil @sebwittr 

# Feature List

- Changed the structure of our ES mapping to make sections a nested property. This allows to us to have nested queries and maps the sections directly to the classes withing Elasticsearch. This is necessary for doing multiple section filters.
- Changed the current query to use a nested query for any section filters.
- Added some code to filter out any sections from the results that don't match all the filters.

# Notes (Optional)

The aggregations are still inaccurate (if you turn on the honors filter, and then click the campus filter you'll see that there are a lot of campus options that lead to no results after clicking it). We'll need to make a separate ticket for this!

# Reviewers

Primary reviewer: @pranavphadke1 @soulwa 

Secondary reviewers:
@ananyaspatil @Anzhuo-W 

Original results:
<img width="1511" alt="image" src="https://github.com/sandboxnu/course-catalog-api/assets/79394243/9c2fa22d-34bf-4123-b223-6ea0720142af">
With the new filtering:
<img width="1511" alt="image" src="https://github.com/sandboxnu/course-catalog-api/assets/79394243/f0f679f1-4b09-4db5-b3a1-a26c19a1b633">

