### PR TITLE
Refactor serializers

### DIFF
--- a/graphql/resolvers/class.ts
+++ b/graphql/resolvers/class.ts
@@ -12,10 +12,10 @@ import {
 import { Course, Section } from "../../types/types";
 import { GraphQLError } from "graphql";
 
-const serializer = new HydrateCourseSerializer();
-
 const serializeValues = (results: PrismaCourse[]): Course[] => {
-  return results.map((result) => serializer.serializeCourse(result));
+  return results.map((result) =>
+    HydrateCourseSerializer.serializeCourse(result)
+  );
 };
 
 const getLatestClassOccurrence = async (
@@ -38,8 +38,7 @@ const getLatestClassOccurrence = async (
       }
     );
   }
-
-  return serializer.serializeCourse(result);
+  return HydrateCourseSerializer.serializeCourse(result);
 };
 
 const getBulkClassOccurrences = async (
@@ -92,7 +91,7 @@ const getClassOccurrence = async (
     );
   }
 
-  return serializer.serializeCourse(result);
+  return HydrateCourseSerializer.serializeCourse(result);
 };
 
 const getClassOccurrenceById = async (id: string): Promise<Course> => {
@@ -111,7 +110,7 @@ const getClassOccurrenceById = async (id: string): Promise<Course> => {
       }
     );
   }
-  return serializer.serializeCourse(result);
+  return HydrateCourseSerializer.serializeCourse(result);
 };
 
 const getSectionById = async (id: string): Promise<Section> => {
@@ -129,8 +128,7 @@ const getSectionById = async (id: string): Promise<Section> => {
       }
     );
   }
-
-  const resSec: Section = serializer.serializeSection(result); // this mutates res
+  const resSec: Section = HydrateCourseSerializer.serializeSection(result); // this mutates res
   const { termId, subject, classId } = keys.parseSectionHash(id);
 
   return { termId, subject, classId, ...resSec };

--- a/scripts/populateES.ts
+++ b/scripts/populateES.ts
@@ -16,7 +16,7 @@ export async function bulkUpsertCourses(
   courses: Course[]
 ): Promise<Promise<unknown>> {
   // FIXME this pattern is bad
-  const serializedCourses = await new ElasticCourseSerializer().bulkSerialize(
+  const serializedCourses = await ElasticCourseSerializer.bulkSerialize(
     courses,
     true
   );
@@ -26,9 +26,7 @@ export async function bulkUpsertCourses(
 export async function bulkUpsertProfs(
   profs: Professor[]
 ): Promise<Promise<unknown>> {
-  const serializedProfs = await new ElasticProfSerializer().bulkSerialize(
-    profs
-  );
+  const serializedProfs = await ElasticProfSerializer.bulkSerialize(profs);
   return elastic.bulkIndexFromMap(elastic.EMPLOYEE_ALIAS, serializedProfs);
 }
 

--- a/serializers/elasticCourseSerializer.ts
+++ b/serializers/elasticCourseSerializer.ts
@@ -2,8 +2,6 @@
  * This file is part of Search NEU and licensed under AGPL3.
  * See the license file in the root folder for details.
  */
-import _ from "lodash";
-
 import CourseSerializer from "./courseSerializer";
 import { ESCourse, ESSection } from "../types/serializerTypes";
 
@@ -13,18 +11,24 @@ class ElasticCourseSerializer extends CourseSerializer<ESCourse, ESSection> {
   }
 
   finishCourseObj(course): ESCourse {
-    return _.pick(course, [
-      "host",
-      "name",
-      "subject",
-      "classId",
-      "termId",
-      "nupath",
-    ]);
+    const keys = ["host", "name", "subject", "classId", "termId", "nupath"];
+
+    return keys.reduce((acc, key) => {
+      if (key in course) {
+        acc[key] = course[key];
+      }
+      return acc;
+    }, {} as ESCourse);
   }
 
   finishSectionObj(section): ESSection {
-    return _.pick(section, ["profs", "classType", "crn", "campus", "honors"]);
+    const keys = ["profs", "classType", "crn", "campus", "honors"];
+    return keys.reduce((acc, key) => {
+      if (key in section) {
+        acc[key] = section[key];
+      }
+      return acc;
+    }, {} as ESSection);
   }
 }
 

--- a/serializers/elasticCourseSerializer.ts
+++ b/serializers/elasticCourseSerializer.ts
@@ -5,12 +5,12 @@
 import CourseSerializer from "./courseSerializer";
 import { ESCourse, ESSection } from "../types/serializerTypes";
 
-class ElasticCourseSerializer extends CourseSerializer<ESCourse, ESSection> {
-  courseProps(): string[] {
+class ElasticCourseSerializer extends CourseSerializer {
+  static courseProps(): string[] {
     return [];
   }
 
-  finishCourseObj(course): ESCourse {
+  static finishCourseObj(course): ESCourse {
     const keys = ["host", "name", "subject", "classId", "termId", "nupath"];
 
     return keys.reduce((acc, key) => {
@@ -21,7 +21,7 @@ class ElasticCourseSerializer extends CourseSerializer<ESCourse, ESSection> {
     }, {} as ESCourse);
   }
 
-  finishSectionObj(section): ESSection {
+  static finishSectionObj(section): ESSection {
     const keys = ["profs", "classType", "crn", "campus", "honors"];
     return keys.reduce((acc, key) => {
       if (key in section) {

--- a/serializers/elasticProfSerializer.ts
+++ b/serializers/elasticProfSerializer.ts
@@ -2,14 +2,19 @@
  * This file is part of Search NEU and licensed under AGPL3.
  * See the license file in the root folder for details.
  */
-import _ from "lodash";
 import ProfSerializer from "./profSerializer";
 import { Professor as PrismaProfessor } from "@prisma/client";
 import { ESProfessor } from "../types/serializerTypes";
 
 class ElasticProfSerializer extends ProfSerializer<ESProfessor> {
   _serializeProf(prof: PrismaProfessor): ESProfessor {
-    return _.pick(prof, ["id", "name", "email", "phone"]);
+    const keys = ["id", "name", "email", "phone"];
+    return Object.keys(prof).reduce((acc, key) => {
+      if (keys.includes(key)) {
+        acc[key] = prof[key];
+      }
+      return acc;
+    }, {} as ESProfessor);
   }
 }
 

--- a/serializers/elasticProfSerializer.ts
+++ b/serializers/elasticProfSerializer.ts
@@ -7,7 +7,7 @@ import { Professor as PrismaProfessor } from "@prisma/client";
 import { ESProfessor } from "../types/serializerTypes";
 
 class ElasticProfSerializer extends ProfSerializer<ESProfessor> {
-  _serializeProf(prof: PrismaProfessor): ESProfessor {
+  static _serializeProf(prof: PrismaProfessor): ESProfessor {
     const keys = ["id", "name", "email", "phone"];
     return Object.keys(prof).reduce((acc, key) => {
       if (keys.includes(key)) {

--- a/serializers/hydrateCourseSerializer.ts
+++ b/serializers/hydrateCourseSerializer.ts
@@ -2,7 +2,6 @@
  * This file is part of Search NEU and licensed under AGPL3.
  * See the license file in the root folder for details.
  */
-import _ from "lodash";
 import CourseSerializer from "./courseSerializer";
 import { Course, Section } from "../types/types";
 import { SerializedSection } from "../types/serializerTypes";

--- a/serializers/hydrateCourseSerializer.ts
+++ b/serializers/hydrateCourseSerializer.ts
@@ -20,7 +20,8 @@ class HydrateCourseSerializer extends CourseSerializer<Course, Section> {
     // We know this will work, but Typescript doesn't
     //  In the main class, we add the fields from this.courseProps() to the section
     //  This creates a proper Section, but TS doesn't know we do that.
-    return _.omit(section, ["id", "classHash"]) as unknown as Section;
+    const { id, classHash, ...rest } = section;
+    return rest as unknown as Section;
   }
 }
 

--- a/serializers/hydrateCourseSerializer.ts
+++ b/serializers/hydrateCourseSerializer.ts
@@ -7,16 +7,16 @@ import CourseSerializer from "./courseSerializer";
 import { Course, Section } from "../types/types";
 import { SerializedSection } from "../types/serializerTypes";
 
-class HydrateCourseSerializer extends CourseSerializer<Course, Section> {
-  courseProps(): string[] {
+class HydrateCourseSerializer extends CourseSerializer {
+  static courseProps(): string[] {
     return ["lastUpdateTime", "termId", "host", "subject", "classId"];
   }
 
-  finishCourseObj(course: Course): Course {
+  static finishCourseObj(course: Course): Course {
     return course;
   }
 
-  finishSectionObj(section: SerializedSection): Section {
+  static finishSectionObj(section: SerializedSection): Section {
     // We know this will work, but Typescript doesn't
     //  In the main class, we add the fields from this.courseProps() to the section
     //  This creates a proper Section, but TS doesn't know we do that.

--- a/serializers/hydrateProfSerializer.ts
+++ b/serializers/hydrateProfSerializer.ts
@@ -6,7 +6,7 @@ import ProfSerializer from "./profSerializer";
 import { Professor as PrismaProfessor } from "@prisma/client";
 
 class HydrateProfSerializer extends ProfSerializer<PrismaProfessor> {
-  _serializeProf(prof: PrismaProfessor): PrismaProfessor {
+  static _serializeProf(prof: PrismaProfessor): PrismaProfessor {
     return prof;
   }
 }

--- a/serializers/hydrateSerializer.ts
+++ b/serializers/hydrateSerializer.ts
@@ -16,15 +16,10 @@ import {
 } from "../types/searchTypes";
 
 class HydrateSerializer {
-  courseSerializer: HydrateCourseSerializer;
-  profSerializer: HydrateProfSerializer;
+  static courseSerializer: HydrateCourseSerializer;
+  static profSerializer: HydrateProfSerializer;
 
-  constructor() {
-    this.courseSerializer = new HydrateCourseSerializer();
-    this.profSerializer = new HydrateProfSerializer();
-  }
-
-  async bulkSerialize(instances: any[]): Promise<SearchResult[]> {
+  static async bulkSerialize(instances: any[]): Promise<SearchResult[]> {
     const profs = instances.filter((instance) => {
       return instance._source.type === "employee";
     });
@@ -49,11 +44,11 @@ class HydrateSerializer {
       },
     });
 
-    const serializedProfs = (await this.profSerializer.bulkSerialize(
+    const serializedProfs = (await HydrateProfSerializer.bulkSerialize(
       profData
     )) as Record<string, ProfessorSearchResult>;
 
-    const serializedCourses = (await this.courseSerializer.bulkSerialize(
+    const serializedCourses = (await HydrateCourseSerializer.bulkSerialize(
       courseData
     )) as Record<string, CourseSearchResult>;
 

--- a/serializers/profSerializer.ts
+++ b/serializers/profSerializer.ts
@@ -2,7 +2,6 @@
  * This file is part of Search NEU and licensed under AGPL3.
  * See the license file in the root folder for details.
  */
-import _ from "lodash";
 import { Professor as PrismaProfessor } from "@prisma/client";
 import { SerializedProfessor } from "../types/serializerTypes";
 
@@ -10,12 +9,12 @@ class ProfSerializer<T extends Partial<PrismaProfessor>> {
   async bulkSerialize(
     instances: PrismaProfessor[]
   ): Promise<Record<string, SerializedProfessor<T>>> {
-    return _.keyBy(
-      instances.map((instance) => {
-        return this._bulkSerializeProf(this._serializeProf(instance));
-      }),
-      (res) => res.employee.id
-    );
+    const result: Record<string, SerializedProfessor<T>> = {};
+    instances.forEach((instance) => {
+      const serialProf = this._bulkSerializeProf(this._serializeProf(instance));
+      result[serialProf.employee.id] = serialProf;
+    });
+    return result;
   }
 
   _bulkSerializeProf(prof: T): SerializedProfessor<T> {

--- a/serializers/profSerializer.ts
+++ b/serializers/profSerializer.ts
@@ -6,10 +6,13 @@ import { Professor as PrismaProfessor } from "@prisma/client";
 import { SerializedProfessor } from "../types/serializerTypes";
 
 class ProfSerializer<T extends Partial<PrismaProfessor>> {
-  async bulkSerialize(
+  static async bulkSerialize(
     instances: PrismaProfessor[]
-  ): Promise<Record<string, SerializedProfessor<T>>> {
-    const result: Record<string, SerializedProfessor<T>> = {};
+  ): Promise<Record<string, SerializedProfessor<Partial<PrismaProfessor>>>> {
+    const result: Record<
+      string,
+      SerializedProfessor<Partial<PrismaProfessor>>
+    > = {};
     instances.forEach((instance) => {
       const serialProf = this._bulkSerializeProf(this._serializeProf(instance));
       result[serialProf.employee.id] = serialProf;
@@ -17,7 +20,9 @@ class ProfSerializer<T extends Partial<PrismaProfessor>> {
     return result;
   }
 
-  _bulkSerializeProf(prof: T): SerializedProfessor<T> {
+  static _bulkSerializeProf(
+    prof: Partial<PrismaProfessor>
+  ): SerializedProfessor<Partial<PrismaProfessor>> {
     return {
       employee: prof,
       type: "employee",
@@ -25,7 +30,7 @@ class ProfSerializer<T extends Partial<PrismaProfessor>> {
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  _serializeProf(prof: PrismaProfessor): T {
+  static _serializeProf(prof: PrismaProfessor): Partial<PrismaProfessor> {
     throw new Error("serializeProf not implemented");
   }
 }

--- a/services/searcher.ts
+++ b/services/searcher.ts
@@ -459,7 +459,7 @@ class Searcher {
     let resultOutput: SearchResult[];
 
     if (showCourse) {
-      resultOutput = await new HydrateSerializer().bulkSerialize([result]);
+      resultOutput = await HydrateSerializer.bulkSerialize([result]);
 
       aggregations = this.getSingleResultAggs({
         ...result._source?.class,
@@ -545,9 +545,7 @@ class Searcher {
       );
       ({ resultCount, took, aggregations } = searchResults);
       const startHydrate = Date.now();
-      results = await new HydrateSerializer().bulkSerialize(
-        searchResults.output
-      );
+      results = await HydrateSerializer.bulkSerialize(searchResults.output);
       hydrateDuration = Date.now() - startHydrate;
     }
 


### PR DESCRIPTION
# Purpose

Lodash is unnecessary and can be replaced by native features. Serializer methods are better suited as static methods. 

# Tickets

https://github.com/orgs/sandboxnu/projects/20?pane=issue&itemId=80651976

# Contributors

@Anzhuo-W , @nickpfeiffer05 

# Feature List

1. Removed reliance on Lodash in all serializer files
    - The previous serializers used many Lodash functions (.pick, .groupBy, etc.), that can now be replaced easily by modern JS features
    - PR has replaced all old Lodash functions with native JS
2. Conversion to static methods
    - Converted all serializer methods to static
    - Adjusted the use of serializers from instanced-calling to static-calling in `searcher.ts`

# Reviewers

**Primary**:

@ananyaspatil 

**Secondary**:

@mehallhm , @cherman23 