### PR TITLE
Add section filters

### DIFF
--- a/services/searcher.ts
+++ b/services/searcher.ts
@@ -10,7 +10,6 @@ import {
 import prisma from "../services/prisma";
 import elastic, { Elastic } from "../utils/elastic";
 import HydrateSerializer from "../serializers/hydrateSerializer";
-import HydrateCourseSerializer from "../serializers/hydrateCourseSerializer";
 import macros from "../utils/macros";
 import {
   EsQuery,
@@ -422,6 +421,39 @@ class Searcher {
     };
   }
 
+  filterOutSections(
+    results: SearchResult[],
+    filters: FilterInput
+  ): SearchResult[] {
+    return results
+      .map((result) => {
+        if (result.type === "employee") {
+          return result;
+        }
+
+        result.sections = result.sections.filter((section) => {
+          return Object.keys(filters).every((filter) => {
+            const filterValue = filters[filter];
+            switch (filter) {
+              case "honors":
+                return section.honors === filterValue;
+              case "subject":
+                return (filterValue as string[]).includes(section.subject);
+              case "campus":
+                return (filterValue as string[]).includes(section.campus);
+              case "classType":
+                return (filterValue as string[]).includes(section.classType);
+              default:
+                return true;
+            }
+          });
+        });
+
+        return result.sections.length > 0 ? result : null;
+      })
+      .filter((result) => result !== null) as SearchResult[];
+  }
+
   generateAgg(filter: string, value: string, count: number): AggCount {
     const agg: AggCount = { value, count };
     // in addition to the subject abbreviation, add subject description for subject filter
@@ -548,6 +580,7 @@ class Searcher {
       results = await new HydrateSerializer().bulkSerialize(
         searchResults.output
       );
+      results = this.filterOutSections(results, filters);
       hydrateDuration = Date.now() - startHydrate;
     }
 


### PR DESCRIPTION
# Purpose

In returned results, only show specific sections that match all filters of the classes with at least one section that matches filters.

Before:
<img width="1444" alt="Screen Shot 2024-10-27 at 2 59 24 PM" src="https://github.com/user-attachments/assets/7dec6602-4643-4227-8137-3dccb993fb3b">

After:
<img width="1443" alt="Screen Shot 2024-10-27 at 3 00 23 PM" src="https://github.com/user-attachments/assets/afd024aa-097b-4e7e-a6a5-c74c50c9f787">

# Tickets

Addresses #233 

# Contributors

@Anzhuo-W 

# Feature List

When campus filters are applied, sections are only displayed for that campus instead of all sections for a course where at least one section is on that campus. The sections are filtered out from the results after they are returned by query; additionally applies to honors sections, class type, and subject.

# Reviewers

Primary reviewer:
@ananyaspatil 

Secondary reviewers:
@nickpfeiffer05 @cherman23 @mehallhm 