### PR TITLE
count only active term notifications

### DIFF
--- a/services/notificationsManager.ts
+++ b/services/notificationsManager.ts
@@ -15,10 +15,36 @@ class NotificationsManager {
   async getUserSubscriptions(phoneNumber: string): Promise<UserInfo> {
     const userId = (await prisma.user.findFirst({ where: { phoneNumber } })).id;
     const followedSections = await prisma.followedSection.findMany({
-      where: { userId },
+      where: {
+        userId,
+        section: {
+          course: {
+            termId: {
+              in: (
+                await prisma.termInfo.findMany({
+                  where: { active: true },
+                  select: { termId: true },
+                })
+              ).map((term) => term.termId),
+            },
+          },
+        },
+      },
     });
     const followedCourses = await prisma.followedCourse.findMany({
-      where: { userId },
+      where: {
+        userId,
+        course: {
+          termId: {
+            in: (
+              await prisma.termInfo.findMany({
+                where: { active: true },
+                select: { termId: true },
+              })
+            ).map((term) => term.termId),
+          },
+        },
+      },
     });
 
     return {

--- a/tests/database/notificationsManager.test.seq.ts
+++ b/tests/database/notificationsManager.test.seq.ts
@@ -82,8 +82,8 @@ describe("user subscriptions", () => {
 
     expect(await notifs.getUserSubscriptions(phoneNumber)).toEqual({
       phoneNumber,
-      sectionIds,
-      courseIds,
+      sectionIds: [],
+      courseIds: [],
     });
   });
 
@@ -97,7 +97,7 @@ describe("user subscriptions", () => {
     expect(await notifs.getUserSubscriptions(phoneNumber)).toEqual({
       phoneNumber,
       sectionIds: [],
-      courseIds,
+      courseIds: [],
     });
 
     await notifs.deleteAllUserSubscriptions(phoneNumber);

--- a/tests/database/notificationsManager.test.seq.ts
+++ b/tests/database/notificationsManager.test.seq.ts
@@ -53,8 +53,8 @@ describe("user subscriptions", () => {
     await notifs.putUserSubscriptions(phoneNumber, sectionIds, courseIds);
     expect(await notifs.getUserSubscriptions(phoneNumber)).toEqual({
       phoneNumber,
-      sectionIds,
-      courseIds,
+      sectionIds: [],
+      courseIds: [],
     });
   });
 


### PR DESCRIPTION
Count only active term notifications to unblock users from being unable to sub/unsub to notifications because of subscriptions created in prior semesters.