### PR TITLE
Add logic to unsubscribe phone number from notifs when STOP_ALL reply

### DIFF
--- a/tests/general/twilio.test.ts
+++ b/tests/general/twilio.test.ts
@@ -111,7 +111,9 @@ describe("TwilioNotifyer", () => {
         },
       };
 
-      const deleteSpy = jest.spyOn(notificationsManager, "deleteAllUserSubscriptions").mockResolvedValue(undefined);;
+      const deleteSpy = jest
+        .spyOn(notificationsManager, "deleteAllUserSubscriptions")
+        .mockResolvedValue(undefined);
       // @ts-expect-error - it's not the exact same type, but I don't care
       await notifs.handleUserReply(req, mockRes);
       expect(deleteSpy).toHaveBeenCalledWith("911");

--- a/tests/general/twilio.test.ts
+++ b/tests/general/twilio.test.ts
@@ -88,7 +88,7 @@ describe("TwilioNotifyer", () => {
       mockRes.send.mockClear();
     });
 
-    it("should handle unknown user replies", () => {
+    it("should handle unknown user replies", async () => {
       const req: Partial<express.Request> = {
         body: {
           Body: "this is a fake message that means nothing",
@@ -97,13 +97,13 @@ describe("TwilioNotifyer", () => {
       };
 
       // @ts-expect-error - it's not the exact same type, but I don't care
-      notifs.handleUserReply(req, mockRes);
+      await notifs.handleUserReply(req, mockRes);
       expect(mockRes.send.mock.calls[0][0]).toMatch(
         /failed to understand your message/i,
       );
     });
 
-    it("should handle a 'Stop all' request", () => {
+    it("should handle a 'Stop all' request", async () => {
       const req: Partial<express.Request> = {
         body: {
           Body: notifs.TWILIO_REPLIES["STOP_ALL"],
@@ -111,9 +111,9 @@ describe("TwilioNotifyer", () => {
         },
       };
 
-      const deleteSpy = jest.spyOn(notificationsManager, "deleteAllUserSubscriptions");
+      const deleteSpy = jest.spyOn(notificationsManager, "deleteAllUserSubscriptions").mockResolvedValue(undefined);;
       // @ts-expect-error - it's not the exact same type, but I don't care
-      notifs.handleUserReply(req, mockRes);
+      await notifs.handleUserReply(req, mockRes);
       expect(deleteSpy).toHaveBeenCalledWith("911");
       expect(mockRes.send.mock.calls[0][0]).toMatch(/have been removed/i);
     });

--- a/tests/general/twilio.test.ts
+++ b/tests/general/twilio.test.ts
@@ -111,8 +111,10 @@ describe("TwilioNotifyer", () => {
         },
       };
 
+      const deleteSpy = jest.spyOn(notificationsManager, "deleteAllUserSubscriptions");
       // @ts-expect-error - it's not the exact same type, but I don't care
       notifs.handleUserReply(req, mockRes);
+      expect(deleteSpy).toHaveBeenCalledWith("911");
       expect(mockRes.send.mock.calls[0][0]).toMatch(/have been removed/i);
     });
   });

--- a/twilio/notifs.ts
+++ b/twilio/notifs.ts
@@ -151,7 +151,10 @@ class TwilioNotifyer {
       });
   }
 
-  async handleUserReply(req: express.Request, res: express.Response): Promise<void> {
+  async handleUserReply(
+    req: express.Request,
+    res: express.Response,
+  ): Promise<void> {
     const message = req.body.Body;
     const senderNumber = req.body.From;
 

--- a/twilio/notifs.ts
+++ b/twilio/notifs.ts
@@ -151,7 +151,7 @@ class TwilioNotifyer {
       });
   }
 
-  handleUserReply(req: express.Request, res: express.Response): void {
+  async handleUserReply(req: express.Request, res: express.Response): Promise<void> {
     const message = req.body.Body;
     const senderNumber = req.body.From;
 
@@ -165,7 +165,7 @@ class TwilioNotifyer {
         twimlResponse.message(
           "You have been removed from all SearchNEU notifications.",
         );
-        notificationsManager.deleteAllUserSubscriptions(senderNumber);
+        await notificationsManager.deleteAllUserSubscriptions(senderNumber);
         break;
       default:
         twimlResponse.message(

--- a/twilio/notifs.ts
+++ b/twilio/notifs.ts
@@ -165,6 +165,7 @@ class TwilioNotifyer {
         twimlResponse.message(
           "You have been removed from all SearchNEU notifications.",
         );
+        notificationsManager.deleteAllUserSubscriptions(senderNumber);
         break;
       default:
         twimlResponse.message(


### PR DESCRIPTION
# Purpose

The code adds logic to unsubscribe phone number from notifs when STOP_ALL reply.

# Tickets

#249 

# Contributors

@ItsEricSun , @nickpfeiffer05 

# Feature List

- Add logic to unsubscribe phone number 
- from notifs 
- when STOP_ALL reply

# Reviewers

Primary reviewer:


**Primary**: @ananyaspatil

Use the **"Reviewers"** feature in Github

Secondary reviewers:

**Secondary**:

@cherman23 
@mehallhm 
@WesleyTran0 
@nickpfeiffer05 
@ItsEricSun 