### PR TITLE
Local notification provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "dev": "NODE_ENV=dev node --watch $(yarn babel-node-ts graphql/index.ts)",
     "about:dev:notifs": "//// Runs the API server along with the notifications server",
     "dev:notifs": "ENABLE_NOTIFS=true yarn dev",
+    "about:dev:notifs:local": "//// Runs the API server along with the notifications server",
+    "dev:notifs:local": "ENABLE_NOTIFS=true NOTIFS_PROVIDER=local yarn dev",
     "about:scrape": "//// Scrapes ALL of the latest class data from Banner",
     "scrape": "yarn babel-node-ts --max_old_space_size=12000 scrapers/main.ts",
     "about:scrape:custom": "//// Runs a scrape with some custom configuration. Read the backend docs for more info",

--- a/twilio/local.ts
+++ b/twilio/local.ts
@@ -1,0 +1,34 @@
+import { TwilioResponse } from "./notifs";
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+} from "express";
+
+class LocalNotifyer {
+  async sendNotificationText(
+    recipientNumber: string,
+    message: string,
+  ): Promise<void> {
+    console.log(`Message for ${recipientNumber}\nMessage: ${message}`);
+  }
+
+  async sendVerificationCode(recipientNumber: string): Promise<TwilioResponse> {
+    // Any code will always be accepted but a randomly generated verification code
+    // is printed to the terminal because it makes people feel good
+    const verificationCode = "" + Math.floor(Math.random() * 1000000);
+    console.log("Verification Code: " + verificationCode.padStart(6, "0"));
+    return { statusCode: 200, message: "Verification code sent!" };
+  }
+
+  async checkVerificationCode(
+    recipientNumber: string,
+    code: string,
+  ): Promise<TwilioResponse> {
+    return { statusCode: 200, message: "Successfully verified!" };
+  }
+
+  handleUserReply(req: ExpressRequest, res: ExpressResponse): void {}
+}
+
+const instance = new LocalNotifyer();
+export default instance;


### PR DESCRIPTION
# Purpose
A tiny local notification provider to allow development on the frontend w/o needing a twilio account or needing to spend the twilio trial credits while developing. To enable, run `yarn dev:notifs:local` which uses the local provider. Any valid phone number will work and any 6 digit code will be valid. The same number will keep the account between sessions.

# Tickets
#256 

# Feature List
- Added the `dev:notifs:local` command to use the local provider
- Added a local verification provider

# Reviewers
@cherman23 
@nickpfeiffer05 
@WesleyTran0 
@ItsEricSun 
