### PR TITLE
Active terms

### DIFF
--- a/graphql/typeDefs/termInfo.js
+++ b/graphql/typeDefs/termInfo.js
@@ -9,6 +9,7 @@ const typeDef = gql`
     termId: String!
     subCollege: String!
     text: String!
+    active: Boolean!
   }
 `;
 

--- a/services/updater.ts
+++ b/services/updater.ts
@@ -30,6 +30,8 @@ At most, there are 12 terms that we want to update - if we're in the spring & su
 
 TODO - once #178 is merged, we should switch to that! Only update the active terms.
 */
+
+// activeTerms are now stored; the updater now only updates activeTerms
 export const NUMBER_OF_TERMS_TO_UPDATE = 12;
 
 const FAULTY_TERM_IDS = ["202225"];
@@ -52,6 +54,7 @@ class Updater {
   SECTION_MODEL: ModelName;
   SEMS_TO_UPDATE: string[];
 
+  // method now unused (other than in tests) since we are only updating activeTerms
   static async getTermIdsToUpdate(): Promise<string[]> {
     const termsStr = process.env.TERMS_TO_SCRAPE;
 
@@ -70,7 +73,7 @@ class Updater {
   }
   // produce a new Updater instance
   static async create(): Promise<Updater> {
-    return new this(await Updater.getTermIdsToUpdate());
+    return new this(macros.activeTermIds);
   }
 
   // The constructor should never be directly called - use .create()
@@ -102,7 +105,7 @@ class Updater {
       setInterval(async () => {
         // Every subsequent run should re-check the term IDs. This checks if any new terms have been added (eg. if the scraper
         // ran and added a new term)
-        this.SEMS_TO_UPDATE = await Updater.getTermIdsToUpdate();
+        this.SEMS_TO_UPDATE = macros.activeTermIds;
         await this.updateOrExit();
       }, intervalTime);
     }

--- a/services/updater.ts
+++ b/services/updater.ts
@@ -31,7 +31,7 @@ At most, there are 12 terms that we want to update - if we're in the spring & su
 TODO - once #178 is merged, we should switch to that! Only update the active terms.
 */
 
-// activeTerms are now stored; the updater now only updates activeTerms
+// Once #281 is marged - activeTerms are now stored; the updater now only updates activeTerms
 export const NUMBER_OF_TERMS_TO_UPDATE = 12;
 
 const FAULTY_TERM_IDS = ["202225"];

--- a/twilio/server.ts
+++ b/twilio/server.ts
@@ -98,6 +98,16 @@ app.put("/user/subscriptions", (req, res) => {
   try {
     const decodedToken = jwt.verify(token, process.env.JWT_SECRET) as any;
     const phoneNumber = decodedToken.phoneNumber;
+
+    // filter out any classes that aren't 'active' adding to a user's notifications
+    sectionIds.filter((s: string) => macros.activeTermIds.includes(s.slice(8,14)));
+    courseIds.filter((s: string) => macros.activeTermIds.includes(s.slice(8,14)));
+
+    if (sectionIds.length === 0 && courseIds.length === 0) { 
+      res.status(204).send();
+      return;
+    }
+
     notificationsManager
       .putUserSubscriptions(phoneNumber, sectionIds, courseIds)
       .then(() => {

--- a/twilio/server.ts
+++ b/twilio/server.ts
@@ -100,10 +100,8 @@ app.put("/user/subscriptions", (req, res) => {
     const phoneNumber = decodedToken.phoneNumber;
 
     // filter out any classes that aren't 'active' adding to a user's notifications
-    sectionIds.filter((s: string) => macros.activeTermIds.includes(s.slice(8,14)));
-    courseIds.filter((s: string) => macros.activeTermIds.includes(s.slice(8,14)));
-
-    if (sectionIds.length === 0 && courseIds.length === 0) { 
+    if (sectionIds.filter((s: string) => macros.activeTermIds.includes(s.slice(8,14))).length === 0 
+    && courseIds.filter((s: string) => macros.activeTermIds.includes(s.slice(8,14))).length === 0) {
       res.status(204).send();
       return;
     }

--- a/utils/macros.ts
+++ b/utils/macros.ts
@@ -105,8 +105,8 @@ class Macros {
   activeTermIds: string[];
 
   constructor() {
-    // Fall 25, Summ2 25, Summ2Full 25, Summ1 25
-    this.activeTermIds = ["202610", "202560", "202550", "202540"];
+    // Fall 25, Summ2 25, Summ2Full 25, Summ1 25, Spring 25
+    this.activeTermIds = ["202610", "202560", "202550", "202540", "202530"];
 
     this.logLevel = getLogLevel(process.env.LOG_LEVEL);
 

--- a/utils/macros.ts
+++ b/utils/macros.ts
@@ -101,7 +101,13 @@ class Macros {
   TEST: boolean;
   DEV: boolean;
 
+  // Manuelly set to provide speed - Need to be programmatically updated in the future
+  activeTermIds: string[];
+
   constructor() {
+    // Fall 25, Summ2 25, Summ2Full 25, Summ1 25
+    this.activeTermIds = ["202610", "202560", "202550", "202540"];
+
     this.logLevel = getLogLevel(process.env.LOG_LEVEL);
 
     this.envLevel = getEnvLevel();


### PR DESCRIPTION
# Purpose

- Giving us more access on what terms are 'active'
- Notifications will only be added if they are for an 'active' class

# Tickets

#281 

# Contributors
@WesleyTran0 


# Feature List

- Added activeTerms list of strings to macro. This will be manually changed until further notice
- updater now only updates active terms. Every previous call to 'getActiveTerms' are now replaced with the recently added macros.activeTermIds
- active field is now added to termId in graphQL endpoints. This feature is reflected on the front end as well (will be mentioned in another PR to the frontend)
- prevents subscriptions to classes that aren't a part of any active terms. Filters out both section and course lists and if there are no classes to add to subscriptions after the filtering, return with a code of 204 rather than just returning 200 (may be confusing)

# Notes (Optional)

Will be connected to another PR to the front end to make the graphQL endpoint for active field accessibile on the front end

# Reviewers

Primary reviewer:

**Primary**: @mehallhm 

Secondary reviewers:

**Secondary**: @cherman23 @ItsEricSun @nickpfeiffer05 @ananyaspatil 
