### PR TITLE
Notification limit on endpoints

### DIFF
--- a/twilio/server.ts
+++ b/twilio/server.ts
@@ -108,7 +108,7 @@ app.put("/user/subscriptions", async (req, res) => {
       return;
     } else if (
       notif_subscriptions.courseIds.length +
-        notif_subscriptions.sectionIds.length >
+        notif_subscriptions.sectionIds.length >=
       SUBSCRIPTION_LIMIT
     ) {
       res.status(403).send();


### PR DESCRIPTION
# Purpose

The limit on notifications is only enforced on the frontend. It needs to be enforced by the API as well.

# Tickets

#264 

# Contributors

@cherman23 

# Feature List

- checks for user being under limit prior to adding a subscription

Primary reviewer:

@mehallhm 
@ananyaspatil 

Secondary reviewers:

@ItsEricSun 
@nickpfeiffer05 
@WesleyTran0 